### PR TITLE
Transfer imperative metavars to Ott file, proper Require-Imports

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build coqdoc
         uses: coq-community/docker-coq-action@v1
         with:
-          custom_image: 'coqorg/coq:8.18'
+          custom_image: 'coqorg/coq:8.19'
           custom_script: |
             {{before_install}}
             startGroup "Build dependencies"
@@ -56,7 +56,7 @@ jobs:
 
       - name: Deploy to GitHub pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        uses: crazy-max/ghaction-github-pages@v2
+        uses: crazy-max/ghaction-github-pages@v4
         with:
           build_dir: public
           jekyll: false

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'coqorg/coq:8.20'
           - 'coqorg/coq:8.19'
           - 'coqorg/coq:8.18'
       fail-fast: false

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,6 @@
 -Q theories ABS
 
--arg -w -arg -deprecated-hint-without-locality
+-arg -w -arg -deprecated-syntactic-definition-since-8.20
 
 theories/abs_defs.v
 theories/abs_examples.v

--- a/meta.yml
+++ b/meta.yml
@@ -50,6 +50,7 @@ dependencies:
     [Coq-Std++](https://gitlab.mpi-sws.org/iris/stdpp) 1.9.0 or later
 
 tested_coq_opam_versions:
+- version: '8.20'
 - version: '8.19'
 - version: '8.18'
 

--- a/src/abs.ott
+++ b/src/abs.ott
@@ -1,14 +1,11 @@
 embed
 {{ coq
-Require Export Ascii.
-Require Export String.
-Require Export ZArith.
-Require Import Lia.
 From Equations Require Import Equations.
+From stdpp Require Import prelude strings gmap.
 
 #[export] Hint Resolve bool_dec : ott_coq_equality.
-#[export] Hint Resolve ascii_dec : ott_coq_equality.
-#[export] Hint Resolve Pos.eq_dec : ott_coq_equality.
+#[export] Hint Resolve Ascii.ascii_dec : ott_coq_equality.
+#[export] Hint Resolve BinPos.Pos.eq_dec : ott_coq_equality.
 
 (** * ABS Definitions *)
 }}
@@ -102,11 +99,7 @@ ctxv :: ctxv_ ::=
 
 embed
 {{ coq
-
-From stdpp Require Export
-    list
-    fin_maps
-    gmap.
+From stdpp Require Import gmap.
 }}
 
 grammar

--- a/src/abs.ott
+++ b/src/abs.ott
@@ -97,11 +97,6 @@ ctxv :: ctxv_ ::=
      | sig :: :: sig
      | Fut < T > :: :: fut
 
-embed
-{{ coq
-From stdpp Require Import gmap.
-}}
-
 grammar
 G {{ tex \Gamma }} :: G_ ::=
   {{ coq gmap x ctxv }}

--- a/src/abs.ott
+++ b/src/abs.ott
@@ -17,7 +17,7 @@ indexvar i, j, n ::=
       {{ coq nat }}
       {{ coq-equality }}
       {{ com index variables (subscripts) }}
-metavar fn ::=
+metavar fc ::=
       {{ lex Alphanum }}
       {{ coq string }}
       {{ coq-equality }}
@@ -39,9 +39,29 @@ metavar z ::=
   {{ coq Z }}
 metavar fut ::=
   {{ lex numeral }}
-  {{ com future }}
+  {{ com future type }}
   {{ coq-equality }}
   {{ coq nat }}
+metavar f ::=
+  {{ lex alphanum }}
+  {{ com future name }}
+  {{ coq-equality }}
+  {{ coq string }}
+metavar o ::=
+  {{ lex alphanum }}
+  {{ com object name }}
+  {{ coq-equality }}
+  {{ coq string }}
+metavar m ::=
+  {{ lex alphanum }}
+  {{ com method name }}
+  {{ coq-equality }}
+  {{ coq string }}
+metavar C ::=
+  {{ lex alphanum }}
+  {{ com class name }}
+  {{ coq-equality }}
+  {{ coq string }}
 grammar
 T :: T_ ::=
    {{ com ground type }}
@@ -50,7 +70,7 @@ T :: T_ ::=
 
 F :: F_ ::=
   {{ com function definition }}
-  | def T fn ( T1 x1 , ... , Tn xn ) = e ; :: :: fn
+  | def T fc ( T1 x1 , ... , Tn xn ) = e ; :: :: fn
 
 t :: t_ ::=
   {{ com ground term }}
@@ -67,7 +87,7 @@ e :: e_ ::=
     {{ com term }}
   | x :: :: var
     {{ com variable }}
-  | fn ( e1 , ... , en ) :: :: fn_call
+  | fc ( e1 , ... , en ) :: :: fn_call
     {{ com function call }}
   | e [ x1 |-> y1 , ... , xn |-> yn ] :: M :: subst_var
     {{ coq (e_var_subst [[e]] [[x1 |-> y1 ... xn |-> yn]]) }}
@@ -121,8 +141,8 @@ formula :: formula_ ::=
     {{ coq (lookup [[x]] [[G]] = Some (ctxv_T [[T]])) }}
   | s ( x ) = t :: M :: s_eq_t
     {{ coq (lookup [[x]] [[s]] = Some ([[t]])) }}
-  | G ( fn ) = sig :: M :: G_fn_eq_sig
-    {{ coq (lookup [[fn]] [[G]] = Some (ctxv_sig [[sig]])) }}
+  | G ( fc ) = sig :: M :: G_fn_eq_sig
+    {{ coq (lookup [[fc]] [[G]] = Some (ctxv_sig [[sig]])) }}
   | distinct ( x1 , ... , xn ) :: M :: distinct_vars
     {{ coq (NoDup [[x1 ... xn]]) }}
   | fresh ( x1 , ... , xn , e ) :: M :: fresh_e
@@ -188,9 +208,9 @@ defn
   G |- x : T
 
   G |- e1 : T1 ... G |- en : Tn
-  G ( fn ) = T1 , ... , Tn -> T
+  G ( fc ) = T1 , ... , Tn -> T
   ----------------------------- :: func_expr
-  G |- fn ( e1 , ... , en ) : T
+  G |- fc ( e1 , ... , en ) : T
 
 defns
   function_well_typing :: typ_ ::=
@@ -199,11 +219,11 @@ defn
   G |- F :: :: F :: ''
     {{ com well-typed function declaration }} by
 
-  G ( fn ) = T1 , ... , Tn -> T
+  G ( fc ) = T1 , ... , Tn -> T
   G [ x1 |-> T1 , ... , xn |-> Tn ] |- e : T
   distinct (x1 , ... , xn)
   ------------------------------------------- :: func_decl
-  G |- def T fn ( T1 x1 , ... , Tn xn ) = e ;
+  G |- def T fc ( T1 x1 , ... , Tn xn ) = e ;
 
 defns
   evaluation_reduction :: red_ ::=
@@ -218,9 +238,9 @@ defn
 
   F1 ... Fn , s |- e ~> s' |- e'
   ------------------------------------------------------------------------------------------------------------- :: fun_exp
-  F1 ... Fn , s |- fn ( e1 , ... , ei , e , e'1 , ... , e'j ) ~> s' |- fn ( e1 , ... , ei , e' , e'1 , ... , e'j )
+  F1 ... Fn , s |- fc ( e1 , ... , ei , e , e'1 , ... , e'j ) ~> s' |- fc ( e1 , ... , ei , e' , e'1 , ... , e'j )
 
   well_formed (y1 , ... , yn , e, s)
   disjoint ((y1 , ... , yn) , (x1 , ... , xn))
   ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- :: fun_ground
-  F1 ... Fi def T fn ( T1 x1 , ... , Tn xn ) = e ; F'1 ... F'j , s |- fn ( t1 , ... , tn ) ~> s [ y1 |-> t1 , ... , yn |-> tn ] |- e [ x1 |-> y1 , ... , xn |-> yn ]
+  F1 ... Fi def T fc ( T1 x1 , ... , Tn xn ) = e ; F'1 ... F'j , s |- fc ( t1 , ... , tn ) ~> s [ y1 |-> t1 , ... , yn |-> tn ] |- e [ x1 |-> y1 , ... , xn |-> yn ]

--- a/theories/abs_defs.v
+++ b/theories/abs_defs.v
@@ -24,12 +24,12 @@ Proof.
   decide equality; auto with ott_coq_equality arith.
 Defined.
 Hint Resolve eq_i : ott_coq_equality.
-Definition fn : Set := string. (*r function name *)
-Lemma eq_fn: forall (x y : fn), {x = y} + {x <> y}.
+Definition fc : Set := string. (*r function name *)
+Lemma eq_fc: forall (x y : fc), {x = y} + {x <> y}.
 Proof.
   decide equality; auto with ott_coq_equality arith.
 Defined.
-Hint Resolve eq_fn : ott_coq_equality.
+Hint Resolve eq_fc : ott_coq_equality.
 Definition x : Set := string. (*r variable *)
 Lemma eq_x: forall (x' y : x), {x' = y} + {x' <> y}.
 Proof.
@@ -48,12 +48,36 @@ Proof.
   decide equality; auto with ott_coq_equality arith.
 Defined.
 Hint Resolve eq_z : ott_coq_equality.
-Definition fut : Set := nat. (*r future *)
+Definition fut : Set := nat. (*r future type *)
 Lemma eq_fut: forall (x y : fut), {x = y} + {x <> y}.
 Proof.
   decide equality; auto with ott_coq_equality arith.
 Defined.
 Hint Resolve eq_fut : ott_coq_equality.
+Definition f : Set := string. (*r future name *)
+Lemma eq_f: forall (x y : f), {x = y} + {x <> y}.
+Proof.
+  decide equality; auto with ott_coq_equality arith.
+Defined.
+Hint Resolve eq_f : ott_coq_equality.
+Definition o : Set := string. (*r object name *)
+Lemma eq_o: forall (x y : o), {x = y} + {x <> y}.
+Proof.
+  decide equality; auto with ott_coq_equality arith.
+Defined.
+Hint Resolve eq_o : ott_coq_equality.
+Definition m : Set := string. (*r method name *)
+Lemma eq_m: forall (x y : m), {x = y} + {x <> y}.
+Proof.
+  decide equality; auto with ott_coq_equality arith.
+Defined.
+Hint Resolve eq_m : ott_coq_equality.
+Definition C : Set := string. (*r class name *)
+Lemma eq_C: forall (x y : C), {x = y} + {x <> y}.
+Proof.
+  decide equality; auto with ott_coq_equality arith.
+Defined.
+Hint Resolve eq_C : ott_coq_equality.
 
 Inductive T : Set :=  (*r ground type *)
  | T_bool : T
@@ -70,7 +94,7 @@ Inductive sig : Set :=
 Inductive e : Set :=  (*r expression *)
  | e_t (t5:t) (*r term *)
  | e_var (x5:x) (*r variable *)
- | e_fn_call (fn5:fn) (_:list e) (*r function call *).
+ | e_fn_call (fc5:fc) (_:list e) (*r function call *).
 
 Inductive ctxv : Set := 
  | ctxv_T (T5:T)
@@ -78,7 +102,7 @@ Inductive ctxv : Set :=
  | ctxv_fut (T5:T).
 
 Inductive F : Set :=  (*r function definition *)
- | F_fn (T_5:T) (fn5:fn) (_:list (T*x)) (e5:e).
+ | F_fn (T_5:T) (fc5:fc) (_:list (T*x)) (e5:e).
 (** induction principles *)
 Section e_rect.
 
@@ -89,7 +113,7 @@ Variables
 Hypothesis
   (H_e_t : forall (t5:t), P_e (e_t t5))
   (H_e_var : forall (x5:x), P_e (e_var x5))
-  (H_e_fn_call : forall (e_list:list e), P_list_e e_list -> forall (fn5:fn), P_e (e_fn_call fn5 e_list))
+  (H_e_fn_call : forall (e_list:list e), P_list_e e_list -> forall (fc5:fc), P_e (e_fn_call fc5 e_list))
   (H_list_e_nil : P_list_e nil)
   (H_list_e_cons : forall (e0:e), P_e e0 -> forall (e_l:list e), P_list_e e_l -> P_list_e (cons e0 e_l)).
 
@@ -97,7 +121,7 @@ Fixpoint e_ott_ind (n:e) : P_e n :=
   match n as x return P_e x with
   | (e_t t5) => H_e_t t5
   | (e_var x5) => H_e_var x5
-  | (e_fn_call fn5 e_list) => H_e_fn_call e_list (((fix e_list_ott_ind (e_l:list e) : P_list_e e_l := match e_l as x return P_list_e x with nil => H_list_e_nil | cons e1 xl => H_list_e_cons e1(e_ott_ind e1)xl (e_list_ott_ind xl) end)) e_list) fn5
+  | (e_fn_call fc5 e_list) => H_e_fn_call e_list (((fix e_list_ott_ind (e_l:list e) : P_list_e e_l := match e_l as x return P_list_e x with nil => H_list_e_nil | cons e1 xl => H_list_e_cons e1(e_ott_ind e1)xl (e_list_ott_ind xl) end)) e_list) fc5
 end.
 
 End e_rect.
@@ -153,19 +177,19 @@ Inductive typ_e : G -> e -> T -> Prop :=    (* defn e *)
  | typ_var : forall (G5:G) (x5:x) (T5:T),
       (lookup  x5   G5  = Some (ctxv_T  T5 ))  ->
      typ_e G5 (e_var x5) T5
- | typ_func_expr : forall (e_T_list:list (e*T)) (G5:G) (fn5:fn) (T_5:T),
+ | typ_func_expr : forall (e_T_list:list (e*T)) (G5:G) (fc5:fc) (T_5:T),
      (forall e_ T_, In (e_,T_) (map (fun (pat_: (e*T)) => match pat_ with (e_,T_) => (e_,T_) end) e_T_list) -> (typ_e G5 e_ T_)) ->
-      (lookup  fn5   G5  = Some (ctxv_sig  (sig_sig (map (fun (pat_:(e*T)) => match pat_ with (e_,T_) => T_ end ) e_T_list) T_5) ))  ->
-     typ_e G5 (e_fn_call fn5 (map (fun (pat_:(e*T)) => match pat_ with (e_,T_) => e_ end ) e_T_list)) T_5.
+      (lookup  fc5   G5  = Some (ctxv_sig  (sig_sig (map (fun (pat_:(e*T)) => match pat_ with (e_,T_) => T_ end ) e_T_list) T_5) ))  ->
+     typ_e G5 (e_fn_call fc5 (map (fun (pat_:(e*T)) => match pat_ with (e_,T_) => e_ end ) e_T_list)) T_5.
 (** definitions *)
 
 (* defns function_well_typing *)
 Inductive typ_F : G -> F -> Prop :=    (* defn F *)
- | typ_func_decl : forall (T_x_list:list (T*x)) (G5:G) (T_5:T) (fn5:fn) (e5:e),
-      (lookup  fn5   G5  = Some (ctxv_sig  (sig_sig (map (fun (pat_:(T*x)) => match pat_ with (T_,x_) => T_ end ) T_x_list) T_5) ))  ->
+ | typ_func_decl : forall (T_x_list:list (T*x)) (G5:G) (T_5:T) (fc5:fc) (e5:e),
+      (lookup  fc5   G5  = Some (ctxv_sig  (sig_sig (map (fun (pat_:(T*x)) => match pat_ with (T_,x_) => T_ end ) T_x_list) T_5) ))  ->
      typ_e  (foldr (fun (xT : x * T) (G0 : G) => insert (fst xT) (ctxv_T (snd xT)) G0)  G5   (map (fun (pat_:(T*x)) => match pat_ with (T_,x_) => (x_,T_) end ) T_x_list) )  e5 T_5 ->
       (NoDup  (map (fun (pat_:(T*x)) => match pat_ with (T_,x_) => x_ end ) T_x_list) )  ->
-     typ_F G5 (F_fn T_5 fn5 T_x_list e5).
+     typ_F G5 (F_fn T_5 fc5 T_x_list e5).
 (** definitions *)
 
 (* defns evaluation_reduction *)
@@ -173,12 +197,12 @@ Inductive red_e : list F -> s -> e -> s -> e -> Prop :=    (* defn e *)
  | red_var : forall (F_list:list F) (s5:s) (x5:x) (t5:t),
       (lookup  x5   s5  = Some ( t5 ))  ->
      red_e F_list s5 (e_var x5) s5 (e_t t5)
- | red_fun_exp : forall (e'_list e_list:list e) (F_list:list F) (s5:s) (fn5:fn) (e_5:e) (s':s) (e':e),
+ | red_fun_exp : forall (e'_list e_list:list e) (F_list:list F) (s5:s) (fc5:fc) (e_5:e) (s':s) (e':e),
      red_e F_list s5 e_5 s' e' ->
-     red_e F_list s5 (e_fn_call fn5 ((app e_list (app (cons e_5 nil) (app e'_list nil))))) s' (e_fn_call fn5 ((app e_list (app (cons e' nil) (app e'_list nil)))))
- | red_fun_ground : forall (T_x_t_y_list:list (T*x*t*x)) (F'_list F_list:list F) (T_5:T) (fn5:fn) (e5:e) (s5:s),
+     red_e F_list s5 (e_fn_call fc5 ((app e_list (app (cons e_5 nil) (app e'_list nil))))) s' (e_fn_call fc5 ((app e_list (app (cons e' nil) (app e'_list nil)))))
+ | red_fun_ground : forall (T_x_t_y_list:list (T*x*t*x)) (F'_list F_list:list F) (T_5:T) (fc5:fc) (e5:e) (s5:s),
       (well_formed  e5   s5   (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => y_ end ) T_x_t_y_list) )  ->
       (disjoint  (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => y_ end ) T_x_t_y_list)   (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => x_ end ) T_x_t_y_list) )  ->
-     red_e ((app F_list (app (cons (F_fn T_5 fn5 (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (T_,x_) end ) T_x_t_y_list) e5) nil) (app F'_list nil)))) s5 (e_fn_call fn5 (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (e_t t_) end ) T_x_t_y_list))  (foldr (fun (xt : x * t) (s0 : s) => insert (fst xt) (snd xt) s0)  s5   (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (y_,t_) end ) T_x_t_y_list) )   (e_var_subst  e5   (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (x_,y_) end ) T_x_t_y_list) ) .
+     red_e ((app F_list (app (cons (F_fn T_5 fc5 (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (T_,x_) end ) T_x_t_y_list) e5) nil) (app F'_list nil)))) s5 (e_fn_call fc5 (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (e_t t_) end ) T_x_t_y_list))  (foldr (fun (xt : x * t) (s0 : s) => insert (fst xt) (snd xt) s0)  s5   (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (y_,t_) end ) T_x_t_y_list) )   (e_var_subst  e5   (map (fun (pat_:(T*x*t*x)) => match pat_ with (T_,x_,t_,y_) => (x_,y_) end ) T_x_t_y_list) ) .
 
 

--- a/theories/abs_defs.v
+++ b/theories/abs_defs.v
@@ -100,6 +100,10 @@ Inductive ctxv : Set :=
 
 Inductive F : Set :=  (*r function definition *)
  | F_fn (T_5:T) (fc5:fc) (_:list (T*x)) (e5:e).
+
+Definition s : Type := gmap x t.
+
+Definition G : Type := gmap x ctxv.
 (** induction principles *)
 Section e_rect.
 
@@ -122,12 +126,6 @@ Fixpoint e_ott_ind (n:e) : P_e n :=
 end.
 
 End e_rect.
-From stdpp Require Import gmap.
-
-
-Definition s : Type := gmap x t.
-
-Definition G : Type := gmap x ctxv.
 
 Equations e_var_subst_one (e5:e) (x_ y_: x) : e := {
  e_var_subst_one (e_t t) _ _ := e_t t;

--- a/theories/abs_defs.v
+++ b/theories/abs_defs.v
@@ -6,15 +6,12 @@ Require Import List.
 Require Import Ott.ott_list_core.
 
 
-Require Export Ascii.
-Require Export String.
-Require Export ZArith.
-Require Import Lia.
 From Equations Require Import Equations.
+From stdpp Require Import prelude strings gmap.
 
 #[export] Hint Resolve bool_dec : ott_coq_equality.
-#[export] Hint Resolve ascii_dec : ott_coq_equality.
-#[export] Hint Resolve Pos.eq_dec : ott_coq_equality.
+#[export] Hint Resolve Ascii.ascii_dec : ott_coq_equality.
+#[export] Hint Resolve BinPos.Pos.eq_dec : ott_coq_equality.
 
 (** * ABS Definitions *)
 
@@ -125,11 +122,7 @@ Fixpoint e_ott_ind (n:e) : P_e n :=
 end.
 
 End e_rect.
-
-From stdpp Require Export
-    list
-    fin_maps
-    gmap.
+From stdpp Require Import gmap.
 
 
 Definition s : Type := gmap x t.

--- a/theories/abs_examples.v
+++ b/theories/abs_examples.v
@@ -1,5 +1,5 @@
+From stdpp Require Import prelude strings.
 From ABS Require Import abs_defs.
-From stdpp Require Import prelude base.
 
 (** * ABS Examples *)
 

--- a/theories/abs_functional_metatheory.v
+++ b/theories/abs_functional_metatheory.v
@@ -1,8 +1,6 @@
+From stdpp Require Import prelude gmap.
 From ABS Require Import abs_defs utils.
-
 From Equations Require Import Equations.
-
-Import ListNotations.
 
 (** * ABS Functional Metatheory *)
 

--- a/theories/abs_functional_metatheory.v
+++ b/theories/abs_functional_metatheory.v
@@ -1,5 +1,4 @@
-From ABS Require Import abs_defs
-  utils.
+From ABS Require Import abs_defs utils.
 
 From Equations Require Import Equations.
 
@@ -9,7 +8,7 @@ Import ListNotations.
 
 Section FunctionalMetatheory.
 
-Hypothesis (vars_fs_distinct: forall (x_:x) (fn_:fn), x_ <> fn_).
+Hypothesis (vars_fs_distinct: forall (x_:x) (fn_:fc), x_ <> fn_).
 Hypothesis (vars_well_typed: forall (x_:x) (G0: G) T0,
              lookup x_ G0 = Some T0 ->
              exists T_, T0 = ctxv_T T_).
@@ -550,7 +549,7 @@ Proof.
 
   - (* RED_FUN_GROUND *)
     intros.
-    set (fn_def:=(F_fn T_5 fn5 (map (fun '(T_, x_, _, _) => (T_, x_)) T_x_t_y_list) e5)).
+    set (fn_def:=(F_fn T_5 fc5 (map (fun '(T_, x_, _, _) => (T_, x_)) T_x_t_y_list) e5)).
     pose proof utils.in_split F_list F'_list fn_def .
     rewrite app_nil_r in *.
     pose proof Forall_forall (typ_F G5) (F_list ++ [fn_def] ++ F'_list) as (? & _).

--- a/theories/abs_imp.v
+++ b/theories/abs_imp.v
@@ -1,44 +1,11 @@
+From stdpp Require Import prelude natmap gmultiset.
+From ABS Require Import abs_defs utils abs_functional_metatheory.
+
 (* Imperative semantics based on FASE-20 paper – not generated from Ott, but probably should be *)
-From stdpp Require Export
-  tactics
-  fin_maps
-  natmap
-  gmultiset
-  sets
-  relations
-.
-From ABS Require Import abs_defs
-utils
-abs_functional_metatheory
-.
 
 Tactic Notation "simp" := simplify_map_eq.
 Tactic Notation "is_eq" ident(a) ident(b) :=
   destruct (decide (a = b)) as [<- | ?].
-
-Definition f : Set := string. (*r future names *)
-Lemma eq_f: forall (x y : f), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-
-Definition o : Set := string. (*r object names *)
-Lemma eq_o: forall (x y : o), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-
-Definition m : Set := string. (*r method names *)
-Lemma eq_m: forall (x y : m), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-
-Definition C : Set := string. (*r class names *)
-Lemma eq_C: forall (x y : C), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
 
 Inductive rhs : Set :=
 | rhs_e (e0:e)
@@ -91,7 +58,7 @@ Section e_rect_set.
   Hypothesis
     (H_e_t : forall (t5:t), P_e (e_t t5))
     (H_e_var : forall (x5:x), P_e (e_var x5))
-    (H_e_fn_call : forall (e_list:list e), P_list_e e_list -> forall (fn5:fn), P_e (e_fn_call fn5 e_list))
+    (H_e_fn_call : forall (e_list:list e), P_list_e e_list -> forall (fc5:fc), P_e (e_fn_call fc5 e_list))
     (H_list_e_nil : P_list_e nil)
     (H_list_e_cons : forall (e0:e), P_e e0 -> forall (e_l:list e), P_list_e e_l -> P_list_e (cons e0 e_l)).
 
@@ -115,7 +82,7 @@ Proof.
   - is_eq x5 x0; auto.
     right.
     inv 1.
-  - is_eq fn5 fn0; auto.
+  - is_eq fc5 fc0; auto.
     + destruct (IHx l); subst; auto.
       right; inv 1.
     + right; inv 1.

--- a/theories/abs_imp.v
+++ b/theories/abs_imp.v
@@ -1,4 +1,4 @@
-From stdpp Require Import prelude natmap gmultiset.
+From stdpp Require Import prelude strings fin_maps natmap gmap gmultiset.
 From ABS Require Import abs_defs utils abs_functional_metatheory.
 
 (* Imperative semantics based on FASE-20 paper – not generated from Ott, but probably should be *)
@@ -11,8 +11,7 @@ Inductive rhs : Set :=
 | rhs_e (e0:e)
 (* we invoke on an object directly, not by some mysterious evaluation to object identifiers *)
 | rhs_invoc (o0:o) (m0:m) (es:list e)
-| rhs_get (f0:f)
-.
+| rhs_get (f0:f).
 
 Inductive stmt : Set :=
 | stmt_seq (s1 s2: stmt)
@@ -100,7 +99,7 @@ Proof.
   unfold EqDecision, Decision.
   decide equality; auto with ott_coq_equality arith.
   - apply e_eq_dec.
-  - apply list_eq_dec.
+  - apply list_eq_dec; apply e_eq_dec.
 Qed.
 Hint Resolve rhs_eq_dec : ott_coq_equality.
 

--- a/theories/utils.v
+++ b/theories/utils.v
@@ -1,7 +1,4 @@
-From Coq Require Import Lia.
-From stdpp Require Export list.
-
-Import ListNotations.
+From stdpp Require Import prelude fin_maps.
 
 Ltac splits := repeat split.
 Tactic Notation "intros*" := repeat intro.


### PR DESCRIPTION
This is to declare the metavars in the Ott file and generate the Coq stuff. Also, idiomatic use of stdpp (avoid exports most of the time, Require-Import stdpp prelude at top of every file).

Since this is basically about code hygiene, will merge when CI passes.