### PR TITLE
Incomplete type preservation

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -6,5 +6,6 @@ theories/abs_defs.v
 theories/abs_examples.v
 theories/abs_functional_metatheory.v
 theories/abs_imp.v
+theories/abs_imperative_metatheory.v
 theories/abs_util.v
 theories/list_util.v

--- a/theories/abs_functional_metatheory.v
+++ b/theories/abs_functional_metatheory.v
@@ -8,22 +8,6 @@ Section FunctionalMetatheory.
 
 Hypothesis (vars_fs_distinct: forall (x_:x) (fn_:fc), x_ <> fn_).
 
-Lemma subG_add: forall (G0 G1: G) y T_,
-  G0 ⊆ G1 ->
-  G0 !! y = None ->
-  G0 ⊆ (insert y T_ G1).
-Proof. intros; by apply insert_subseteq_r. Qed.
-
-Lemma subG_add_2: forall (G0 G1: G) y T_,
-  subseteq G0 G1 ->
-  G0 !! y = Some T_ ->
-  subseteq G0 (insert y T_ G1).
-Proof.
-  intros.
-  replace G0 with (<[y:=T_]> G0) by now apply insert_id.
-  now apply insert_mono.
-Qed.
-
 Definition get_type (ctx: ctxv) : T :=
   match ctx with
     | ctxv_T T' => T'

--- a/theories/abs_imp.v
+++ b/theories/abs_imp.v
@@ -45,7 +45,7 @@ Section Semantics.
   Equations get_class_decl (c:C) (l: list CL) : option CL := {
       get_class_decl _ [] := None ;
       get_class_decl c ((class name fields methods)::Cs) :=
-        if String.eqb c name then Some (class name fields methods) else get_class_decl c Cs
+        if decide (c = name) then Some (class name fields methods) else get_class_decl c Cs
     }.
 
   Lemma get_class_decl_some: forall c l C,

--- a/theories/abs_imp.v
+++ b/theories/abs_imp.v
@@ -3,236 +3,681 @@ From ABS Require Import list_util abs_defs abs_util abs_functional_metatheory.
 
 (** * ABS Imperative Metatheory *)
 
+Notation id := nat.
+
 (* Imperative semantics based on FASE-20 paper – not generated from Ott, but probably should be *)
+Section Semantics.
+  Context
+      (Cs: list CL)
+      (Fs: list F)
+      (name_of: id -> f)
+      (id_of: f -> id)
+  .
 
-Equations get_class_name (CL0:CL): C := {get_class_name (class name _ _) := name}.
-Equations get_fields (CL0:CL): list (T*x) := {get_fields (class _ fields _) := fields}.
+  Equations get_class_name (CL0:CL): C := {get_class_name (class name _ _) := name}.
+  Equations get_fields (CL0:CL): list (T*x) := {get_fields (class _ fields _) := fields}.
+  Equations get_methods (CL0:CL): list M := {get_methods (class _ _ methods) := methods}.
 
-Notation queue := (gmultiset task).
+  Equations get_params (_:M): list (T*x) := {get_params (M_m _ _ params _ _ ) := params}.
+  Equations get_type (_:M): T := {get_type (M_m type _ _ _ _ ) := type}.
 
-Inductive cn: Type :=
-| cn_future (f0:f) (v:option t)
-| cn_object (C0:C) (a:s) (p:option task) (q: queue)
-| cn_invoc (o0:o) (f0:f) (m0:m) (vs: list t).
+  Definition queue := (gmultiset task).
 
-Notation config := (natmap cn).
-Definition add (p:task) (q:queue) := q ⊎ {[+ p +]}.
-Definition remove (p:task) (q:queue) := difference q {[+ p +]}.
+  Inductive cn: Type :=
+  | cn_future (f0:f) (v:option t)
+  | cn_object (C0:C) (a:s) (p:option task) (q: queue)
+  | cn_invoc (o0:o) (f0:f) (m0:m) (vs: list t).
 
-Equations get_method_decl (m0:m) (l: list M) : option M := {
-  get_method_decl _ [] := None ;
-  get_method_decl m ((M_m T m' params decl body)::Ms) :=
-      if String.eqb m m' then Some (M_m T m' params decl body) else get_method_decl m Ms
-  }.
+  Definition config := (natmap cn).
+  Definition add (p:task) (q:queue) := (q ⊎ {[+ p +]}).
+  Definition remove (p:task) (q:queue) := (q ∖ {[+ p +]}).
+  Equations get_method_decl (m0:m) (l: list M) : option M := {
+      get_method_decl _ [] := None ;
+      get_method_decl m ((M_m T m' params decl body)::Ms) :=
+        if String.eqb m m' then Some (M_m T m' params decl body) else get_method_decl m Ms
+    }.
 
-Equations bind_params_aux (s0:s) (vs: list t) (params: list (T*x)): s := {
-  bind_params_aux s0 [] _ := s0;
-  bind_params_aux s0 _ [] := s0;
-  bind_params_aux s0 (v::vs) ((_,x)::Txs) := insert x v (bind_params_aux s0 vs Txs)
-  }.
+  #[global] Instance elem_of_list_m: ElemOf m (list M) := fun m ms => get_method_decl m ms <> None.
 
-Definition bind_params := bind_params_aux empty.
+  Equations get_class_decl (c:C) (l: list CL) : option CL := {
+      get_class_decl _ [] := None ;
+      get_class_decl c ((class name fields methods)::Cs) :=
+        if String.eqb c name then Some (class name fields methods) else get_class_decl c Cs
+    }.
 
-Equations bind (m0:m) (vs: list t) (f0:f) (CL0:CL) : option task := {
-  bind m vs f (class n params m_list) :=
-  match get_method_decl m m_list with
-  | None => None
-  | Some (M_m T m' params decl body) =>
-      Some (tsk body (bind_params vs params))
-  end
-  }.
+  #[global] Instance elem_of_list_CL: ElemOf C (list CL) := fun c Cs => get_class_decl c Cs <> None.
 
-Definition reduce (Fs: list F): relation (e * s) :=
-  fun  x y => let (e0, s0) := x in let (e1, s1) := y in red_e Fs s0 e0 s1 e1.
-Definition eval (Fs: list F) (s0:s) (e0:e) (v:t): Prop :=
-  exists sf, (rtc (reduce Fs)) (e0, s0) (e_t v, sf).
+  Equations bind_params_aux (s0:s) (vs: list t) (params: list (T*x)): s := {
+      bind_params_aux s0 [] _ := s0;
+      bind_params_aux s0 _ [] := s0;
+      bind_params_aux s0 (v::vs) ((_,x)::Txs) := insert x v (bind_params_aux s0 vs Txs)
+    }.
 
-Equations eval_list (Fs: list F) (s0:s) (es: list e) (vs: list t): Prop := {
-    eval_list _ _ [] [] := True;
-    eval_list Fs s0 (e::es) (v::vs) := eval Fs s0 e v /\ eval_list Fs s0 es vs;
-    eval_list _ _ _ _ := False
-  }.
+  Definition bind_params := bind_params_aux empty.
 
-#[global]
-Instance elem_of_map: ElemOf x s := fun x s => s !! x <> None.
-#[global]
-Instance elem_of_config: ElemOf nat config := fun x s => s !! x <> None.
+  Equations bind (m0:m) (vs: list t) (f0:f) (CL0:CL) : option task := {
+      bind m vs f (class n params m_list) :=
+        match get_method_decl m m_list with
+        | None => None
+        | Some (M_m T m' params decl body) =>
+            Some (tsk body (bind_params vs params))
+        end
+    }.
 
-Definition destiny: f := "destiny"%string.
+  Definition eval (s0:s) (e0:e) (v:t): Prop :=
+    exists sf, (rtc (reduce Fs)) (e0, s0) (e_t v, sf).
 
-Inductive stmt_step (Fs:list F): list CL -> config -> config -> Prop :=
-| step_activate: forall Cs σ p q i a C,
-    p ∈ q ->
-    σ !! i = Some (cn_object C a None q) ->
-    stmt_step Fs Cs σ (<[i:=(cn_object C a (Some p) (remove p q))]> σ)
+  Equations eval_list (s0:s) (es: list e) (vs: list t): Prop := {
+      eval_list _ [] [] := True;
+      eval_list s0 (e::es) (v::vs) := eval s0 e v /\ eval_list s0 es vs;
+      eval_list _ _ _ := False
+    }.
 
-| step_asgn1: forall Cs σ i a C l x e s q v,
-    x ∈ l ->
-    eval Fs (union a l) e v ->
-    σ !! i = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
-    stmt_step Fs Cs σ (<[i:=(cn_object C a (Some (tsk s (<[x:=v]> l))) q)]> σ)
+  Definition destiny: f := "destiny"%string.
 
-| step_asgn2: forall Cs σ o a C l x e s q v,
-    ~ x ∈ l ->
-    eval Fs (union a l) e v ->
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
-    stmt_step Fs Cs σ (<[o:=(cn_object C (<[x:=v]> a) (Some (tsk s l)) q)]> σ)
+  Definition fresh (f0:f) (σ:config) : Prop := forall i f v, σ !! i = Some (cn_future f v) -> f <> f0.
 
-| step_cond1: forall Cs σ o a C l e s1 s2 s q,
-    eval Fs (union a l) e (t_b true) ->
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a (Some (tsk (stmt_seq s1 s) l)) q]> σ)
+  Inductive stmt_step: config -> config -> Prop :=
+  | step_activate: forall σ p q i a C,
+      p ∈ q ->
+      σ !! i = Some (cn_object C a None q) ->
+      stmt_step σ (<[i:=(cn_object C a (Some p) (remove p q))]> σ)
 
-| step_cond2: forall Cs σ o a C l e s1 s2 s q,
-    eval Fs (union a l) e (t_b false) ->
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a (Some (tsk (stmt_seq s2 s) l)) q]> σ)
+  | step_asgn1: forall σ i a C l x e s q v,
+      x ∈ dom l ->
+      eval (union a l) e v ->
+      σ !! i = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
+      stmt_step σ (<[i:=(cn_object C a (Some (tsk s (<[x:=v]> l))) q)]> σ)
 
-| step_skip1: forall Cs σ o a C l s q,
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq stmt_skip s) l)) q) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a (Some (tsk s l)) q]> σ)
+  | step_asgn2: forall σ o a C l x e s q v,
+      x ∈ dom a ->
+      eval (union a l) e v ->
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
+      stmt_step σ (<[o:=(cn_object C (<[x:=v]> a) (Some (tsk s l)) q)]> σ)
 
-| step_skip2: forall Cs σ o a C l q,
-    σ !! o = Some (cn_object C a (Some (tsk stmt_skip l)) q) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a None q]> σ)
+  | step_cond1: forall σ o a C l e s1 s2 s q,
+      eval (union a l) e (t_b true) ->
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
+      stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq s1 s) l)) q]> σ)
 
-| step_while: forall Cs σ o a C l e s1 s2 q,
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_loop e s1) s2) l)) q) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a (Some ( tsk (stmt_seq (stmt_cond e (stmt_seq s1 (stmt_loop e s1)) stmt_skip) s2) l)) q]> σ)
+  | step_cond2: forall σ o a C l e s1 s2 s q,
+      eval (union a l) e (t_b false) ->
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
+      stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq s2 s) l)) q]> σ)
 
-| step_call: forall Cs σ oi o' a C l q x m es vs s f fi i,
-    ~ fi ∈ σ ->
-    ~ i ∈ σ ->
-    eval_list Fs (union a l) es vs ->
-    σ !! oi = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_invoc o' m es)) s) l)) q) ->
-    stmt_step Fs Cs σ (<[oi:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q]>
-                      (<[i:=cn_invoc o' f m vs]>
-                         (<[fi:=cn_future f None]> σ)))
+  | step_skip1: forall σ o a C l s q,
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq stmt_skip s) l)) q) ->
+      stmt_step σ (<[o:=cn_object C a (Some (tsk s l)) q]> σ)
 
-| step_return: forall Cs σ o a C l e v q f fi,
-    eval Fs (union a l) e v ->
-    σ !! fi = Some (cn_future f None) ->
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_ret e) l)) q) ->
-    l !! destiny = Some (t_fut fi) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a None q]>
-                      (<[fi:=cn_future f (Some v)]> σ))
+  | step_skip2: forall σ o a C l q,
+      σ !! o = Some (cn_object C a (Some (tsk stmt_skip l)) q) ->
+      stmt_step σ (<[o:=cn_object C a None q]> σ)
 
-| step_read: forall Cs σ o a C l x s v q f fi,
-    σ !! fi = Some (cn_future f (Some v)) ->
-    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q) ->
-    stmt_step Fs Cs σ (<[o:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e (e_t v))) s) l)) q]> σ)
+  | step_while: forall σ o a C l e s1 s2 q,
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_loop e s1) s2) l)) q) ->
+      stmt_step σ (<[o:=cn_object C a (Some ( tsk (stmt_seq (stmt_cond e (stmt_seq s1 (stmt_loop e s1)) stmt_skip) s2) l)) q]> σ)
 
-| step_load: forall σ o oi i a p p' q f m vs C CL Cs Cs',
-    σ !! oi = Some (cn_object C a p q) ->
-    σ !! i = Some (cn_invoc o f m vs) ->
-    get_class_name CL = C ->
-    bind m vs f CL = Some p' ->
-    stmt_step Fs (Cs ++ [CL] ++ Cs') σ
-    (<[oi:=cn_object C a p (add p' q)]>
-       (delete i σ))
-.
+  | step_call: forall σ oi o' a C l q x m es vs s f i,
+      fresh f σ ->
+      ~ i ∈ dom σ ->
+      eval_list (union a l) es vs ->
+      σ !! oi = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_invoc o' m es)) s) l)) q) ->
+      stmt_step σ (<[oi:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q]>
+                     (<[i:=cn_invoc o' f m vs]>
+                        (<[id_of f:=cn_future f None]> σ)))
 
-(** Typing *)
+  | step_return: forall σ o a C l e v q f fi,
+      eval (union a l) e v ->
+      σ !! fi = Some (cn_future f None) ->
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_ret e) l)) q) ->
+      l !! destiny = Some (t_fut fi) ->
+      stmt_step σ (<[o:=cn_object C a None q]>
+                     (<[fi:=cn_future f (Some v)]> σ))
+
+  | step_read: forall σ o a C l x s v q f fi,
+      σ !! fi = Some (cn_future f (Some v)) ->
+      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q) ->
+      stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e (e_t v))) s) l)) q]> σ)
+
+  | step_load: forall σ o oi i a p p' q f m vs C CL,
+      σ !! oi = Some (cn_object C a p q) ->
+      σ !! i = Some (cn_invoc o f m vs) ->
+      CL ∈ Cs ->
+      get_class_name CL = C ->
+      bind m vs f CL = Some p' ->
+      stmt_step σ (<[oi:=cn_object C a p (add p' q)]> (delete i σ))
+  .
+End Semantics.
+
+Section Typing.
 (* based on https://link.springer.com/chapter/10.1007/978-3-642-25271-6_8 *)
 
-Inductive typ_method: list CL -> G -> C -> m -> list e -> T -> Prop :=
-(* TODO: implement this *).
-Inductive typ_CL: G -> CL -> Prop :=
-(* TODO: implement this *).
+  Context
+      (Cs: list CL)
+      (Fs: list F)
+      (name_of: id -> f)
+      (id_of: f -> id)
+      (class_of: o -> C)
+  .
 
-Inductive typ_rhs (Cs: list CL): G -> rhs -> ctxv -> Prop :=
-| typ_rhs_e: forall G e T,
-    typ_e G e T ->
-    typ_rhs Cs G (rhs_e e) (ctxv_T T)
-| typ_rhs_invoc: forall G o m es T,
-    typ_method Cs G o m es T ->
-    typ_rhs Cs G (rhs_invoc o m es) (ctxv_fut T)
-| typ_rhs_get: forall G f T,
-    G !! f = Some (ctxv_fut T) ->
-    typ_rhs Cs G (rhs_get f) (ctxv_T T)
-.
+  Hypothesis (vars_fs_distinct: forall (x_:x) (fn:fc), x_ <> fn).
 
-Inductive typ_stmt (Cs: list CL): G -> stmt -> Prop :=
-| typ_stmt_seq: forall G s1 s2,
-    typ_stmt Cs G s1 ->
-    typ_stmt Cs G s2 ->
-    typ_stmt Cs G (stmt_seq s1 s2)
+  Equations typ_es: G -> list e -> list T -> Prop := {
+      typ_es _ [] [] := True ;
+      typ_es Γ (e::es) (T::Ts) := typ_e Γ e T /\ typ_es Γ es Ts ;
+      typ_es _ _ _ := False
+    }.
 
-| typ_stmt_skip: forall G,
-    typ_stmt Cs G stmt_skip
+  Lemma type_preservation_eval: forall Γ,
+      Forall (typ_F Γ) Fs ->
+      forall σ, G_vdash_s Γ σ ->
+           forall e0 e1 T0,
+             typ_e Γ e0 T0 ->
+             eval Fs σ e0 e1 ->
+             typ_e Γ (e_t e1) T0.
+  Proof.
+    intros.
+    destruct H2 as [σ' COMP].
+    pose proof type_preservation vars_fs_distinct  _ _ _ H0 H _ _ _ H1 COMP
+      as (Γ' & SUB & VDASH & TYP).
+    now inv TYP; constructor.
+  Qed.
 
-|typ_stmt_asgn: forall G x r T,
-    G !! x = Some T ->
-    typ_rhs Cs G r T ->
-    typ_stmt Cs G (stmt_asgn x r)
+  Lemma type_preservation_eval_list: forall Γ,
+      Forall (typ_F Γ) Fs ->
+      forall σ, G_vdash_s Γ σ ->
+        forall es vs Ts,
+          typ_es Γ es Ts ->
+          eval_list Fs σ es vs ->
+          typ_es Γ (map e_t vs) Ts.
+  Proof.
+    induction es; intros;
+      destruct vs;
+      destruct Ts;
+      cbn;
+      autorewrite with typ_es eval_list in *;
+      try intuition.
+    eapply type_preservation_eval; eauto.
+  Qed.
 
-| typ_stmt_cond: forall G b s1 s2,
-    typ_e G b T_bool ->
-    typ_stmt Cs G s1 ->
-    typ_stmt Cs G s2 ->
-    typ_stmt Cs G (stmt_cond b s1 s2)
+  Definition add_G (Γ:G) (Tx:T*x): G := <[Tx.2:=ctxv_T Tx.1]> Γ.
+  Definition extend_G (Γ:G) (l:list (T*x)): G := foldr (flip add_G) Γ l.
 
-| typ_stmt_loop: forall G b s,
-    typ_e G b T_bool ->
-    typ_stmt Cs G s ->
-    typ_stmt Cs G (stmt_loop b s)
+  Variant match_method: m -> list T -> T -> CL -> Prop :=
+    match_intro: forall m method Cl,
+        get_method_decl m (get_methods Cl) = Some method ->
+        match_method m (map fst (get_params method)) (get_type method) Cl.
 
-| typ_stmt_return: forall G e T,
-    typ_e G e T ->
-    G !! destiny = Some (ctxv_fut T) ->
-    typ_stmt Cs G (stmt_ret e)
-.
+  Variant typ_rhs: G -> rhs -> ctxv -> Prop :=
+    | typ_rhs_e: forall Γ e T,
+        typ_e Γ e T ->
+        typ_rhs Γ (rhs_e e) (ctxv_T T)
+    | typ_rhs_invoc: forall Γ m o es Cl Ts T,
+        typ_es Γ es Ts ->
+        get_class_decl (class_of o) Cs = Some Cl ->
+        match_method m Ts T Cl ->
+        typ_rhs Γ (rhs_invoc o m es) (ctxv_fut T)
+    | typ_rhs_fut: forall Γ f T,
+        Γ !! f = Some (ctxv_fut T) ->
+        typ_rhs Γ (rhs_get f) (ctxv_T T)
+  .
 
-Definition class_of: o -> C.
-Admitted.
+  Inductive stmt_well_typed: G -> stmt -> Prop :=
+  | typ_stmt_seq: forall G s1 s2,
+      stmt_well_typed G s1 ->
+      stmt_well_typed G s2 ->
+      stmt_well_typed G (stmt_seq s1 s2)
 
-Equations task_well_typed (Cs: list CL) (G0:G) (t:task): Prop := {
-  task_well_typed Cs G0 (tsk p l) := G_vdash_s G0 l /\ typ_stmt Cs G0 p
-  }.
-(* this is a bit weird: the paper treats l sometimes as a list of typed variable bindings and sometimes as local state :/
- if variable bindings then the typ_stmt judgement here should bind those vars in G0 *)
+  | stmt_well_typed_skip: forall G,
+      stmt_well_typed G stmt_skip
 
-Definition queue_well_typed (Cs: list CL) (G0:G) (q:queue): Prop :=
-  forall t, t ∈ q -> task_well_typed Cs G0 t.
+  | stmt_well_typed_asgn: forall G x r T,
+      G !! x = Some T ->
+      typ_rhs G r T ->
+      stmt_well_typed G (stmt_asgn x r)
 
-Inductive cn_well_typed (Cs: list CL): G -> cn -> Prop :=
-| wt_future_none: forall G f T,
-    G !! f = Some (ctxv_fut T) ->
-    cn_well_typed Cs G (cn_future f None)
+  | stmt_well_typed_cond: forall G b s1 s2,
+      typ_e G b T_bool ->
+      stmt_well_typed G s1 ->
+      stmt_well_typed G s2 ->
+      stmt_well_typed G (stmt_cond b s1 s2)
 
-| wt_future_some: forall G f t T,
-    G !! f = Some (ctxv_fut T) ->
-    typ_e G (e_t t) T ->
-    cn_well_typed Cs G (cn_future f (Some t))
+  | stmt_well_typed_loop: forall G b s,
+      typ_e G b T_bool ->
+      stmt_well_typed G s ->
+      stmt_well_typed G (stmt_loop b s)
 
-| wt_invoc: forall G o f m vs T,
-    typ_method Cs G (class_of o) m (map e_t vs) T ->
-    G !! f = Some (ctxv_fut T) ->
-    cn_well_typed Cs G (cn_invoc o f m vs)
+  | stmt_well_typed_return: forall G e T,
+      typ_e G e T ->
+      G !! destiny = Some (ctxv_fut T) ->
+      stmt_well_typed G (stmt_ret e)
+  .
 
-| wt_object_none: forall G C a q,
-    queue_well_typed Cs G q ->
-    cn_well_typed Cs G (cn_object C a None q)
+  Variant task_well_typed: G -> option task -> Prop :=
+    | task_wt_idle: forall Γ, task_well_typed Γ None
+    | task_wt: forall Γ stmt l,
+        (* this differs from the paper since we do not treat l as a typed list *)
+        G_vdash_s Γ l ->
+        stmt_well_typed Γ stmt ->
+        task_well_typed Γ (Some (tsk stmt l))
+  .
 
-| wt_object_some: forall G C a p q,
-    queue_well_typed Cs G q ->
-    task_well_typed Cs G p ->
-    cn_well_typed Cs G (cn_object C a (Some p) q)
-.
+  Definition queue_well_typed (Γ:G) (q:queue) := forall t, t ∈ q -> task_well_typed Γ (Some t).
 
-Definition config_well_typed (Cs: list CL) (G0:G) (conf: config) :=
-  forall i ob, conf !! i = Some ob -> cn_well_typed Cs G0 ob.
+  Variant cn_well_typed: G -> cn -> Prop :=
+    | ob_wt: forall Γ c Cl a p q fields,
+        (* The paper also checks fields(Γ(o)), but we would need another case for ctxv *)
+        get_class_decl c Cs = Some Cl ->
+        get_fields Cl = fields ->
+        queue_well_typed (extend_G Γ fields) q ->
+        task_well_typed (extend_G Γ fields) p ->
+        G_vdash_s (extend_G Γ fields) a ->
+        cn_well_typed Γ (cn_object c a p q)
+    | inv_wt: forall Γ o f T Ts m vs Cl,
+        Γ !! f = Some (ctxv_fut T) ->
+        typ_es Γ (map e_t vs) Ts ->
+        get_class_decl (class_of o) Cs = Some Cl ->
+        match_method m Ts T Cl ->
+        cn_well_typed Γ (cn_invoc o f m vs)
+    | fut_wt_none: forall G f T,
+        G !! f = Some (ctxv_fut T) ->
+        cn_well_typed  G (cn_future f None)
+    | fut_wt_some: forall G f t T,
+        G !! f = Some (ctxv_fut T) ->
+        typ_e G (e_t t) T ->
+        cn_well_typed  G (cn_future f (Some t))
+  .
+  Definition config_well_typed (G0:G) (conf: config) :=
+    forall i ob, conf !! i = Some ob -> cn_well_typed G0 ob.
 
-Theorem type_preservation : forall (Fs: list F) (Cs: list CL) (G0: G),
-    Forall (typ_F G0) Fs ->
-    Forall (typ_CL G0) Cs ->
-    forall σ σ',
-      config_well_typed Cs G0 σ ->
-      stmt_step Fs Cs σ σ' ->
-      exists G',
-        G0 ⊆ G' /\ config_well_typed Cs G' σ'.
-Proof.
-Admitted.
+  (** useful tactics and lemmas *)
 
-(*TODO: subject reduction for stmt_step *)
+  Ltac lookup_cases H i j :=
+    is_eq i j; [setoid_rewrite lookup_insert in H; inv H
+               | setoid_rewrite lookup_insert_ne in H; auto].
+
+  Ltac unfold_typing :=
+    repeat (match goal with
+            | H: cn_well_typed _ _ |- _ => inv H
+            | H: task_well_typed _ _ |- _ => inv H
+            | H: stmt_well_typed _ (stmt_seq _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_asgn _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_cond _ _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_loop _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_ret _) |- _ => inv H
+            | H: typ_rhs _ _ _ |- _ => inv H
+            (* | H: match_method _ _ _ _ |- _ => inv H *)
+            end).
+
+  (* should be a theorem, but will require some assumptions on name_of/id_of and typing of futures *)
+  Hypothesis id_of_consistent: forall (σ:config) f f' v, σ !! (id_of f) = Some (cn_future f' v) -> f = f'.
+  Variant is_fut: cn -> Prop := is_fut_intro: forall f v, is_fut (cn_future f v).
+  Hypothesis id_of_well_typed: forall (σ:config) f c, σ !! (id_of f) = Some c -> is_fut c.
+
+  Lemma fresh_config_wt: forall Γ f σ,
+      fresh f σ -> config_well_typed Γ σ -> f ∉ dom Γ.
+  Proof.
+    unfold fresh, config_well_typed.
+    intros.
+    destruct (σ !! id_of f) eqn:?.
+    - specialize (id_of_well_typed _ _ _ Heqo) as FUT_WT; auto.
+      inv FUT_WT.
+      specialize (H0 _ _ Heqo).
+      specialize (id_of_consistent _ _ _ _ Heqo).
+      intro.
+      eapply H; eauto.
+    - admit.
+      (* this seems problematic *)
+  Admitted.
+
+  Lemma subG_extend: forall Γ l,
+      Forall (fun '(_, x) => x ∉ dom Γ) l ->
+      Γ ⊆ extend_G Γ l.
+  Proof.
+    induction l; intros; auto.
+    destruct a; simpl in *.
+    inv H.
+    eapply subG_add; auto.
+    simpl.
+    now apply not_elem_of_dom.
+  Qed.
+
+  Lemma q_wt_remove: forall  G0 q,
+      queue_well_typed  G0 q ->
+      forall t, queue_well_typed  G0 (remove t q).
+  Proof.
+    intros*.
+    apply H.
+    multiset_solver.
+  Qed.
+
+  Lemma q_wt_add: forall  G0 q,
+      queue_well_typed  G0 q ->
+      forall t,
+        task_well_typed G0 (Some t) ->
+        queue_well_typed  G0 (add t q).
+  Proof.
+    intros*.
+    apply gmultiset_elem_of_disj_union in H1.
+    destruct H1; auto.
+    now apply gmultiset_elem_of_singleton in H1; subst.
+  Qed.
+
+  Lemma G_vdash_union: forall Γ σ σ',
+      G_vdash_s Γ σ ->
+      (* somewhat surprisingly we do not need σ' because map_union prefers the left*)
+      (* G_vdash_s Γ σ' -> *)
+      G_vdash_s Γ (union σ σ').
+  Proof.
+    intros*.
+    apply H in H0.
+    destruct H0 as (?t & LU & TYP).
+    exists t.
+    split; simp; auto.
+  Qed.
+
+  (* this is a problem: well-typing of tasks is not closed under extensions *)
+  Fact subG_task_wt : exists Γ1 Γ2 t,
+      Γ1 ⊆ Γ2 /\ task_well_typed  Γ1 t /\ ~ task_well_typed  Γ2 t.
+  Proof.
+    exists ∅, (<["x":=ctxv_T T_bool]> ∅), (Some (tsk stmt_skip (<["x":=t_int Z0]> ∅))).
+    splits.
+    - now apply insert_subseteq.
+    - econstructor.
+      + intros*.
+        inv H.
+      + constructor.
+    - inv 1.
+      pose proof H3 "x" (ctxv_T T_bool) as (?t' & ? & ?); auto.
+      simpl in H0.
+      inv H0.
+  Qed.
+
+  (* this substitution and subsequent well-typing is not currently used *)
+  (* I thought I might use it, and then didn't, but may be useful later? *)
+  Equations e_subst_s : s -> e -> e := {
+      e_subst_s _ (e_t t) := e_t t;
+      e_subst_s σ (e_var x_) := match σ !! x_ with | Some t => (e_t t) | None => (e_var x_) end ;
+      e_subst_s σ (e_fn_call fn_ es) := e_fn_call fn_ (e_subst_list_s σ es) }
+  where e_subst_list_s: s -> list e -> list e := {
+      e_subst_list_s _ [] := [] ;
+      e_subst_list_s σ (e_::es) := e_subst_s σ e_ :: e_subst_list_s σ es
+    }.
+
+  (* the well-typedness from the paper, ours is a little stricter *)
+  Definition sub_well_typed (Γ : G) (σ : s) :=
+    forall (x_: x) (T_: T),
+      x_ ∈ dom σ ->
+      Γ !! x_ = Some (ctxv_T T_) ->
+      typ_e Γ (e_subst_s σ (e_var x_)) T_.
+
+  Lemma vdash_implies_wt: forall Γ σ,
+      G_vdash_s Γ σ ->
+      sub_well_typed Γ σ.
+  Proof.
+    intros*.
+    pose proof H x_ (ctxv_T T_) H1 as (?t_ & LU & TYP).
+    autorewrite with e_subst_s.
+    now rewrite LU.
+  Qed.
+
+  (* just like our vdash, this is the wrong way *)
+  Lemma subG_sub_wt: forall Γ1 Γ2 σ,
+      Γ1 ⊆ Γ2 -> sub_well_typed Γ2 σ -> sub_well_typed Γ1 σ.
+  Proof.
+    intros*.
+    specialize (H0 x_ T_ H1).
+    autorewrite with e_subst_s in *.
+    apply elem_of_dom in H1.
+    inv H1.
+    setoid_rewrite H3.
+    eapply map_subseteq_spec in H; eauto.
+    apply H0 in H.
+    setoid_rewrite H3 in H.
+    inv H; constructor.
+  Qed.
+
+  Lemma subG_typ_es: forall G1 G2 es Ts,
+      subseteq G1 G2 -> typ_es G1 es Ts -> typ_es G2 es Ts.
+  Proof.
+    induction es; destruct Ts; auto; intros.
+    autorewrite with typ_es in *.
+    destruct H0.
+    split; auto.
+    eapply subG_type; eauto.
+  Qed.
+
+  Lemma subG_typ_rhs: forall G1 G2 r T0,
+      subseteq G1 G2 -> typ_rhs G1 r T0 -> typ_rhs G2 r T0.
+  Proof.
+    intros.
+    inv H0.
+    - econstructor.
+      eapply subG_type; eauto.
+    - econstructor; eauto.
+      eapply subG_typ_es; eauto.
+    - econstructor.
+      eapply lookup_weaken; eauto.
+  Qed.
+
+  Lemma subG_stmt_wt: forall G1 G2 st,
+      subseteq G1 G2 -> stmt_well_typed G1 st -> stmt_well_typed G2 st.
+  Proof.
+    intros.
+    induction H0; eauto;
+      try (now econstructor; eauto).
+    - econstructor.
+      + eapply lookup_weaken; eauto.
+      + eapply subG_typ_rhs; eauto.
+    - econstructor; eauto.
+      eapply subG_type; eauto.
+    - econstructor; eauto.
+      eapply subG_type; eauto.
+    - econstructor.
+      + eapply subG_type; eauto.
+      + eapply lookup_weaken; eauto.
+  Qed.
+
+  Lemma fresh_extend_wt: forall Γ σ f,
+      config_well_typed Γ σ ->
+      fresh f σ ->
+      forall T_,
+        config_well_typed (<[f:=T_]> Γ) σ.
+  Proof.
+  Admitted.
+
+  Theorem type_preservation : forall (Γ: G),
+      Forall (typ_F Γ) Fs ->
+      forall σ σ',
+        config_well_typed Γ σ ->
+        stmt_step Cs Fs id_of σ σ' ->
+        exists Γ', Γ ⊆ Γ' /\ config_well_typed Γ' σ'.
+  Proof.
+    intros.
+    inv H1.
+    - exists Γ; split; auto.
+      intros*.
+      lookup_cases H1 i i0.
+      + specialize (H0 _ _ H3).
+        unfold_typing.
+        destruct p.
+        econstructor; eauto.
+        now apply q_wt_remove.
+      + eapply H0;eauto.
+
+    - destruct H3 as [sf ?].
+      pose proof H1 as Conf_wt.
+      specialize (H0 _ _ H4).
+      unfold_typing.
+      epose proof type_preservation _ _ _ _ _ _ _ _ _ H5 H1
+        as (?Γ & ?SUB & ? & ?TYP_E).
+      (* are tasks actually well-typed under this extension? *)
+      admit.
+      Unshelve.
+      + apply vars_fs_distinct.
+      + now apply G_vdash_union.
+      + apply subG_typ_F_forall with Γ; auto.
+        apply subG_extend.
+        admit. (* can we guarantee that the fields are not already in the context? *)
+
+    - destruct H3 as [sf ?].
+      pose proof H1 as Conf_wt.
+      specialize (H0 _ _ H4).
+      unfold_typing.
+      epose proof type_preservation _ _ _ _ _ _ _ _ _ H5 H1
+        as (?Γ & ?SUB & ? & ?TYP_E).
+      admit.
+
+    (* the trivial cases (ifs, skips, loops) are very similar*)
+    (* TODO: automate *)
+    - pose proof H0 as Conf_wt.
+      specialize (H0 _ _ H3).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H0 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof H0 as Conf_wt.
+      specialize (H0 _ _ H3).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H0 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof H0 as Conf_wt.
+      specialize (H0 _ _ H2).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H0 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof H0 as Conf_wt.
+      specialize (H0 _ _ H2).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H0 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof H0 as Conf_wt.
+      specialize (H0 _ _ H2).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H0 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof H0 as Conf_wt.
+      specialize (H0 _ _ H5).
+      unfold_typing.
+      pose proof H18 as Method_wt.
+      inv H18.
+      destruct method.
+      autorewrite with get_type get_params in *.
+      epose proof type_preservation_eval_list _ _ _ _ _ _ _ H15 H4 as TYP_ARGS.
+      exists (<[f:=ctxv_fut T_5]> Γ).
+      split.
+      + apply subG_add; auto.
+        apply not_elem_of_dom.
+        eapply fresh_config_wt; eauto.
+      + intros*.
+        lookup_cases H1 oi i0.
+        * econstructor; eauto.
+          -- admit.
+          -- constructor; auto.
+             ++ admit.
+             ++ econstructor.
+                ** econstructor; eauto.
+                   --- admit.
+                   --- econstructor.
+                       eapply lookup_weaken with (<[f:=ctxv_fut T_5]> Γ).
+                       +++ apply lookup_insert.
+                       +++ apply subG_extend.
+                           admit.
+                ** eapply subG_stmt_wt.
+                   --- admit.
+                   --- eauto.
+          -- admit. (* should follow from freshness *)
+        * lookup_cases H1 i i0.
+          -- econstructor; eauto.
+             ++ apply lookup_insert.
+             ++ admit. (* I would like to use TYP_ARGS, but that includes the fields from the object *)
+          -- set (fi:=id_of f).
+             is_eq fi i0; subst fi.
+             ++ setoid_rewrite lookup_insert in H1.
+                inv H1.
+                econstructor.
+                apply lookup_insert.
+             ++ setoid_rewrite lookup_insert_ne in H1; auto.
+                eapply fresh_extend_wt; eauto.
+
+    - pose proof H0 _ _ H3 as fut_well_typed.
+      pose proof H0 _ _ H4 as ob_well_typed.
+      exists Γ; split; auto.
+      intros*.
+      unfold_typing.
+      lookup_cases H1 o i.
+      + econstructor; eauto.
+        econstructor.
+      + lookup_cases H1 fi i.
+        * econstructor; eauto.
+          epose proof type_preservation_eval _ _ _ _ _ _ _ H7 H2.
+          enough (T0 = T) by (subst; inv H1; constructor).
+          pose proof (H11 _ _ H14) as (?t & ? & ?); simp.
+          inv H1; inv H9.
+        * eapply H0; eauto.
+
+    - pose proof H0 _ _ H2 as fut_well_typed.
+      pose proof H0 _ _ H3 as ob_well_typed.
+      exists Γ; split; auto.
+      intros*.
+      unfold_typing.
+      lookup_cases H1 o i.
+      + repeat (econstructor; eauto).
+        replace T1 with T by admit. (* follows from f ∉ fields(Cl) *)
+        eapply subG_type with Γ; auto.
+        apply subG_extend.
+        admit.
+      + eapply H0; eauto.
+
+    - pose proof H0 _ _ H2 as ob_well_typed.
+      pose proof H0 _ _ H3 as inv_well_typed.
+      exists Γ; split; auto.
+      intros*.
+      unfold_typing.
+      + lookup_cases H1 oi i0.
+        * repeat (econstructor; eauto).
+          apply q_wt_add; auto.
+          admit. (* here we need Γ ⊢ Cl -> Γ ⊢ bind m vs f*)
+        * is_eq i i0.
+          -- exfalso.
+             setoid_rewrite (lookup_delete σ i) in H1.
+             inv H1.
+          -- setoid_rewrite lookup_delete_ne in H1; auto.
+             eapply H0; eauto.
+      + lookup_cases H1 oi i0.
+        * repeat (econstructor; eauto).
+          apply q_wt_add; auto.
+          admit. (* here we need Γ ⊢ Cl -> Γ ⊢ bind m vs f*)
+        * is_eq i i0.
+          -- exfalso.
+             setoid_rewrite (lookup_delete σ i) in H1.
+             inv H1.
+          -- setoid_rewrite lookup_delete_ne in H1; auto.
+             eapply H0; eauto.
+
+             Unshelve.
+             all: try eauto.
+             all: try (now apply G_vdash_union).
+             (*remaining: typ_F closed under (well-typed?) extensions *)
+  Admitted.
+End Typing.
 (*TODO: labels + traces? *)

--- a/theories/abs_imp.v
+++ b/theories/abs_imp.v
@@ -1,942 +1,151 @@
 From stdpp Require Import prelude strings fin_maps natmap gmap gmultiset.
 From ABS Require Import list_util abs_defs abs_util abs_functional_metatheory.
 
-(** * ABS Imperative Metatheory *)
+(** * Concurrent object level semantics for Core ABS *)
 
 Notation id := nat.
 
 (* Imperative semantics based on FASE-20 paper – not generated from Ott, but probably should be *)
-Section Semantics.
-  Context
-      (Cs: list CL)
-      (Fs: list F)
-      (*name_of should probably be partial to account for non-future ids *)
-      (name_of: id -> f)
-      (id_of: f -> id)
-  .
 
-  Equations get_class_name (CL0:CL): C := {get_class_name (class name _ _) := name}.
-  Equations get_fields (CL0:CL): list (T*x) := {get_fields (class _ fields _) := fields}.
-  Equations get_methods (CL0:CL): list M := {get_methods (class _ _ methods) := methods}.
-
-  Equations get_params (_:M): list (T*x) := {get_params (M_m _ _ params _ _ ) := params}.
-  Equations get_type (_:M): T := {get_type (M_m type _ _ _ _ ) := type}.
-
-  Definition queue := (gmultiset task).
-
-  Inductive cn: Type :=
-  | cn_future (f0:f) (v:option t)
-  | cn_object (C0:C) (a:s) (p:option task) (q: queue)
-  | cn_invoc (o0:o) (f0:f) (m0:m) (vs: list t).
-
-  Variant is_fut: cn -> Prop := is_fut_intro: forall f v, is_fut (cn_future f v).
-
-  Definition config := (natmap cn).
-  Definition add (p:task) (q:queue) := (q ⊎ {[+ p +]}).
-  Definition remove (p:task) (q:queue) := (q ∖ {[+ p +]}).
-  Equations get_method_decl (m0:m) (l: list M) : option M := {
-      get_method_decl _ [] := None ;
-      get_method_decl m ((M_m T m' params decl body)::Ms) :=
-        if String.eqb m m' then Some (M_m T m' params decl body) else get_method_decl m Ms
-    }.
-
-  #[global] Instance elem_of_list_m: ElemOf m (list M) := fun m ms => get_method_decl m ms <> None.
-
-  Equations get_class_decl (c:C) (l: list CL) : option CL := {
-      get_class_decl _ [] := None ;
-      get_class_decl c ((class name fields methods)::Cs) :=
-        if decide (c = name) then Some (class name fields methods) else get_class_decl c Cs
-    }.
-
-  Lemma get_class_decl_some: forall c l C,
-      get_class_decl c l = Some C -> In C l.
-  Proof.
-    induction l; intros; try (now inv H).
-    destruct a.
-    autorewrite with get_class_decl in *.
-    destruct (c =? C5)%string.
-    + inv H.
-      now left.
-    + right; auto.
-  Qed.
-
-  Equations bind_params_aux (s0:s) (vs: list t) (params: list (T*x)): s := {
-      bind_params_aux s0 [] _ := s0;
-      bind_params_aux s0 _ [] := s0;
-      bind_params_aux s0 (v::vs) ((_,x)::Txs) := insert x v (bind_params_aux s0 vs Txs)
-    }.
-
-  Definition bind_params := bind_params_aux empty.
-
-  Equations bind (m0:m) (vs: list t) (f0:f) (CL0:CL) : option task := {
-      bind m vs f (class n params m_list) :=
-        match get_method_decl m m_list with
-        | None => None
-        | Some (M_m T m' params decl body) =>
-            Some (tsk body (bind_params vs params))
-        end
-    }.
-
-  Definition eval (s0:s) (e0:e) (v:t): Prop :=
-    exists sf, (rtc (reduce Fs)) (e0, s0) (e_t v, sf).
-
-  Equations eval_list (s0:s) (es: list e) (vs: list t): Prop := {
-      eval_list _ [] [] := True;
-      eval_list s0 (e::es) (v::vs) := eval s0 e v /\ eval_list s0 es vs;
-      eval_list _ _ _ := False
-    }.
-
-  Definition destiny: f := "destiny"%string.
-
-  Definition fresh (f0:f) (σ:config) : Prop := forall i f v, σ !! i = Some (cn_future f v) -> f <> f0.
-
-  Inductive stmt_step: config -> config -> Prop :=
-  | step_activate: forall σ p q i a C,
-      p ∈ q ->
-      σ !! i = Some (cn_object C a None q) ->
-      stmt_step σ (<[i:=(cn_object C a (Some p) (remove p q))]> σ)
-
-  | step_asgn1: forall σ i a C l x e s q v,
-      x ∈ dom l ->
-      eval (union a l) e v ->
-      σ !! i = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
-      stmt_step σ (<[i:=(cn_object C a (Some (tsk s (<[x:=v]> l))) q)]> σ)
-
-  | step_asgn2: forall σ o a C l x e s q v,
-      x ∈ dom a ->
-      eval (union a l) e v ->
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
-      stmt_step σ (<[o:=(cn_object C (<[x:=v]> a) (Some (tsk s l)) q)]> σ)
-
-  | step_cond1: forall σ o a C l e s1 s2 s q,
-      eval (union a l) e (t_b true) ->
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
-      stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq s1 s) l)) q]> σ)
-
-  | step_cond2: forall σ o a C l e s1 s2 s q,
-      eval (union a l) e (t_b false) ->
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
-      stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq s2 s) l)) q]> σ)
-
-  | step_skip1: forall σ o a C l s q,
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq stmt_skip s) l)) q) ->
-      stmt_step σ (<[o:=cn_object C a (Some (tsk s l)) q]> σ)
-
-  | step_skip2: forall σ o a C l q,
-      σ !! o = Some (cn_object C a (Some (tsk stmt_skip l)) q) ->
-      stmt_step σ (<[o:=cn_object C a None q]> σ)
-
-  | step_while: forall σ o a C l e s1 s2 q,
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_loop e s1) s2) l)) q) ->
-      stmt_step σ (<[o:=cn_object C a (Some ( tsk (stmt_seq (stmt_cond e (stmt_seq s1 (stmt_loop e s1)) stmt_skip) s2) l)) q]> σ)
-
-  | step_call: forall σ oi o' a C l q x m es vs s f i,
-      fresh f σ ->
-      ~ i ∈ dom σ ->
-      eval_list (union a l) es vs ->
-      σ !! oi = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_invoc o' m es)) s) l)) q) ->
-      stmt_step σ (<[oi:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q]>
-                     (<[i:=cn_invoc o' f m vs]>
-                        (<[id_of f:=cn_future f None]> σ)))
-
-  | step_return: forall σ o a C l e v q f fi,
-      eval (union a l) e v ->
-      σ !! fi = Some (cn_future f None) ->
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_ret e) l)) q) ->
-      l !! destiny = Some (t_fut fi) ->
-      stmt_step σ (<[o:=cn_object C a None q]>
-                     (<[fi:=cn_future f (Some v)]> σ))
-
-  | step_read: forall σ o a C l x s v q f fi,
-      σ !! fi = Some (cn_future f (Some v)) ->
-      σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q) ->
-      stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e (e_t v))) s) l)) q]> σ)
-
-  | step_load: forall σ o oi i a p p' q f m vs C CL,
-      σ !! oi = Some (cn_object C a p q) ->
-      σ !! i = Some (cn_invoc o f m vs) ->
-      CL ∈ Cs ->
-      get_class_name CL = C ->
-      bind m vs f CL = Some p' ->
-      stmt_step σ (<[oi:=cn_object C a p (add p' q)]> (delete i σ))
-  .
-End Semantics.
-
-Section Typing.
-(* based on https://link.springer.com/chapter/10.1007/978-3-642-25271-6_8 *)
-
-  Context
-      (Cs: list CL)
-      (Fs: list F)
-      (*name_of should probably be partial to account for non-future ids *)
-      (name_of: id -> f)
-      (id_of: f -> id)
-      (class_of: o -> C)
-  .
-
-  Hypothesis (vars_fs_distinct: forall (x_:x) (fn:fc), x_ <> fn).
-  Hypothesis id_of_consistent: forall (σ:config) f f' v, σ !! (id_of f) = Some (cn_future f' v) -> f = f'.
-  Hypothesis id_of_well_typed: forall (σ:config) f c, σ !! (id_of f) = Some c -> is_fut c.
-  Hypothesis id_of_name_of: forall i, id_of (name_of i) = i.
-  Hypothesis name_of_id_of: forall f, name_of (id_of f) = f.
-
-  (* this substitution and subsequent well-typing is not currently used *)
-  (* I thought I might use it, and then didn't, but may be useful later? *)
-  Equations e_subst_s : s -> e -> e := {
-      e_subst_s _ (e_t t) := e_t t;
-      e_subst_s σ (e_var x_) := match σ !! x_ with | Some t => (e_t t) | None => (e_var x_) end ;
-      e_subst_s σ (e_fn_call fn_ es) := e_fn_call fn_ (e_subst_list_s σ es) }
-  where e_subst_list_s: s -> list e -> list e := {
-      e_subst_list_s _ [] := [] ;
-      e_subst_list_s σ (e_::es) := e_subst_s σ e_ :: e_subst_list_s σ es
-    }.
-
-  (* the well-typedness from the paper, ours is a little stricter *)
-  Definition sub_well_typed (Γ : G) (σ : s) :=
-    forall (x_: x) (T_: T),
-      x_ ∈ dom σ ->
-      Γ !! x_ = Some (ctxv_T T_) ->
-      typ_e Γ (e_subst_s σ (e_var x_)) T_.
-
-  Lemma vdash_implies_wt: forall Γ σ,
-      G_vdash_s Γ σ ->
-      sub_well_typed Γ σ.
-  Proof.
-    intros*.
-    pose proof H x_ (ctxv_T T_) H1 as (?t_ & LU & TYP).
-    autorewrite with e_subst_s.
-    now rewrite LU.
-  Qed.
-
-  (* just like our vdash, this is the wrong way *)
-  Lemma subG_sub_wt: forall Γ1 Γ2 σ,
-      Γ1 ⊆ Γ2 -> sub_well_typed Γ2 σ -> sub_well_typed Γ1 σ.
-  Proof.
-    intros*.
-    specialize (H0 x_ T_ H1).
-    autorewrite with e_subst_s in *.
-    apply elem_of_dom in H1.
-    inv H1.
-    setoid_rewrite H3.
-    eapply map_subseteq_spec in H; eauto.
-    apply H0 in H.
-    setoid_rewrite H3 in H.
-    inv H; constructor.
-  Qed.
-
-  Equations typ_es: G -> list e -> list T -> Prop := {
-      typ_es _ [] [] := True ;
-      typ_es Γ (e::es) (T::Ts) := typ_e Γ e T /\ typ_es Γ es Ts ;
-      typ_es _ _ _ := False
-    }.
-
-  Lemma typ_term_invariant: forall Γ v T,
-      typ_e Γ (e_t v) T ->
-      forall Γ',
-        typ_e Γ' (e_t v) T.
-  Proof.
-    intros.
-    inv H; constructor.
-  Qed.
-
-  Lemma typ_term_list_invariant: forall Γ vs Ts,
-      typ_es Γ (map e_t vs) Ts ->
-      forall Γ',
-        typ_es Γ' (map e_t vs) Ts.
-    Proof.
-      induction vs; destruct Ts; intros; auto.
-      simpl in *.
-      autorewrite with typ_es in *.
-      destruct H.
-      split; auto.
-      eapply typ_term_invariant; eauto.
-    Qed.
-
-  Lemma type_preservation_eval: forall Γ,
-      Forall (typ_F Γ) Fs ->
-      forall σ, G_vdash_s Γ σ ->
-           forall e0 e1 T0,
-             typ_e Γ e0 T0 ->
-             eval Fs σ e0 e1 ->
-             typ_e Γ (e_t e1) T0.
-  Proof.
-    intros.
-    destruct H2 as [σ' COMP].
-    pose proof type_preservation vars_fs_distinct  _ _ _ H0 H _ _ _ H1 COMP
-      as (Γ' & SUB & VDASH & TYP).
-    now inv TYP; constructor.
-  Qed.
-
-  Lemma type_preservation_eval_list: forall Γ,
-      Forall (typ_F Γ) Fs ->
-      forall σ, G_vdash_s Γ σ ->
-        forall es vs Ts,
-          typ_es Γ es Ts ->
-          eval_list Fs σ es vs ->
-          typ_es Γ (map e_t vs) Ts.
-  Proof.
-    induction es; intros;
-      destruct vs;
-      destruct Ts;
-      cbn;
-      autorewrite with typ_es eval_list in *;
-      try intuition.
-    eapply type_preservation_eval; eauto.
-  Qed.
-
-  Definition add_G (Γ:G) (Tx:T*x): G := <[Tx.2:=ctxv_T Tx.1]> Γ.
-  Definition extend_G (Γ:G) (l:list (T*x)): G := foldr (flip add_G) Γ l.
-
-  Lemma extend_subG: forall Γ1 Γ2 l,
-      Γ1 ⊆ Γ2 -> extend_G Γ1 l ⊆ extend_G Γ2 l.
-  Proof.
-    induction l; intros; auto.
-    destruct a; simpl.
-    apply insert_mono.
-    now apply IHl.
-  Qed.
-
-  Lemma subG_extend: forall Γ l,
-      Forall (fun '(_, x) => x ∉ dom Γ) l ->
-      Γ ⊆ extend_G Γ l.
-  Proof.
-    induction l; intros; auto.
-    destruct a; simpl in *.
-    inv H.
-    eapply subG_add; auto.
-    simpl.
-    now apply not_elem_of_dom.
-  Qed.
-
-  Lemma addG_subG: forall Γ1 Γ2 Tx,
-      add_G Γ1 Tx ⊆ Γ2 ->
-      Tx.2 ∉ dom Γ1 ->
-      Γ1 ⊆ Γ2.
-  Proof.
-    unfold add_G.
-    intros.
-    epose proof map_subseteq_spec _ _ as (? & _).
-    pose proof H as H'.
-    eapply H1 with (i:=Tx.2) in H; last eapply lookup_insert.
-    eapply subG_add_2 in H; eauto.
-    transitivity (<[Tx.2:=ctxv_T Tx.1]> Γ1); auto.
-    apply subG_add; auto.
-    now apply not_elem_of_dom.
-  Qed.
-
-  Lemma extend_domain: forall Γ x l,
-      x ∉ dom Γ ->
-      Forall (λ '(_, x0), x0 <> x) l ->
-      x ∉ dom (extend_G Γ l).
-  Proof.
-    induction l; intros; auto.
-    destruct a; simpl in *.
-    inv H0.
-    pose proof IHl H H4.
-    apply not_elem_of_dom.
-    setoid_rewrite lookup_insert_ne; auto.
-    now apply not_elem_of_dom.
-  Qed.
-
-  Lemma extend_subG_2: forall Γ1 Γ2 l,
-      extend_G Γ1 l ⊆ Γ2 ->
-      Forall (λ '(_, x), x ∉ dom Γ2) l ->
-      Γ1 ⊆ Γ2.
-  Proof.
-    induction l; intros; auto.
-    destruct a; simpl in *.
-    inv H0.
-    apply addG_subG in H; auto.
-    apply extend_domain; auto.
-    - eapply lookup_weaken with (i:=x) in H; last apply lookup_insert.
-      apply not_elem_of_dom in H3.
-      setoid_rewrite H3 in H.
-      inv H.
-    - apply Forall_forall.
-      intros (?&?) ? ?.
-      eapply Forall_forall in H4; eauto.
-      simpl in *; subst.
-      eapply lookup_weaken with (i:=x) in H; last apply lookup_insert.
-      apply not_elem_of_dom in H3.
-      setoid_rewrite H3 in H.
-      inv H.
-   Qed.
-
-  Variant match_method: m -> list T -> T -> CL -> Prop :=
-    match_intro: forall m method Cl,
-        get_method_decl m (get_methods Cl) = Some method ->
-        match_method m (map fst (get_params method)) (get_type method) Cl.
-
-  Variant typ_rhs: G -> rhs -> ctxv -> Prop :=
-    | typ_rhs_e: forall Γ e T,
-        typ_e Γ e T ->
-        typ_rhs Γ (rhs_e e) (ctxv_T T)
-    | typ_rhs_invoc: forall Γ m o es Cl Ts T,
-        typ_es Γ es Ts ->
-        get_class_decl (class_of o) Cs = Some Cl ->
-        match_method m Ts T Cl ->
-        typ_rhs Γ (rhs_invoc o m es) (ctxv_T T)
-    | typ_rhs_get: forall Γ f T,
-        Γ !! f = Some (ctxv_fut T) ->
-        typ_rhs Γ (rhs_get f) (ctxv_T T)
-  .
-
-  Inductive stmt_well_typed: G -> stmt -> Prop :=
-  | typ_stmt_seq: forall G s1 s2,
-      stmt_well_typed G s1 ->
-      stmt_well_typed G s2 ->
-      stmt_well_typed G (stmt_seq s1 s2)
-
-  | stmt_well_typed_skip: forall G,
-      stmt_well_typed G stmt_skip
-
-  | stmt_well_typed_asgn: forall G x r T,
-      G !! x = Some T ->
-      typ_rhs G r T ->
-      stmt_well_typed G (stmt_asgn x r)
-
-  | stmt_well_typed_cond: forall G b s1 s2,
-      typ_e G b T_bool ->
-      stmt_well_typed G s1 ->
-      stmt_well_typed G s2 ->
-      stmt_well_typed G (stmt_cond b s1 s2)
-
-  | stmt_well_typed_loop: forall G b s,
-      typ_e G b T_bool ->
-      stmt_well_typed G s ->
-      stmt_well_typed G (stmt_loop b s)
-
-  | stmt_well_typed_return: forall G e T,
-      typ_e G e T ->
-      G !! destiny = Some (ctxv_fut T) ->
-      stmt_well_typed G (stmt_ret e)
-  .
-
-  Variant task_well_typed: G -> option task -> Prop :=
-    | task_wt_idle: forall Γ, task_well_typed Γ None
-    | task_wt: forall Γ stmt l,
-        (* this differs from the paper since we do not treat l as a typed list *)
-        (* G_vdash_s Γ l -> *)
-        stmt_well_typed Γ stmt ->
-        task_well_typed Γ (Some (tsk stmt l))
-  .
-
-  Definition queue_well_typed (Γ:G) (q:queue) := forall t, t ∈ q -> task_well_typed Γ (Some t).
-
-  Variant cn_well_typed: G -> cn -> Prop :=
-    | ob_wt: forall Γ c Cl a p q fields,
-        (* The paper also checks fields(Γ(o)), but we would need another case for ctxv *)
-        get_class_decl c Cs = Some Cl ->
-        get_fields Cl = fields ->
-        queue_well_typed (extend_G Γ fields) q ->
-        task_well_typed (extend_G Γ fields) p ->
-        G_vdash_s (extend_G Γ fields) a ->
-        cn_well_typed Γ (cn_object c a p q)
-    | inv_wt: forall Γ o f T Ts m vs Cl,
-        Γ !! f = Some (ctxv_fut T) ->
-        typ_es Γ (map e_t vs) Ts ->
-        get_class_decl (class_of o) Cs = Some Cl ->
-        match_method m Ts T Cl ->
-        cn_well_typed Γ (cn_invoc o f m vs)
-    | fut_wt_none: forall G f T,
-        G !! f = Some (ctxv_fut T) ->
-        cn_well_typed  G (cn_future f None)
-    | fut_wt_some: forall G f t T,
-        G !! f = Some (ctxv_fut T) ->
-        typ_e G (e_t t) T ->
-        cn_well_typed  G (cn_future f (Some t))
-  .
-  Definition config_well_typed (G0:G) (conf: config) :=
-    forall i ob, conf !! i = Some ob -> cn_well_typed G0 ob.
-
-  Example typing_get: let Γ := (<["x":=ctxv_T T_int]> (<["f":=ctxv_fut T_int]> ∅)) in
-                      stmt_well_typed Γ (stmt_asgn "x" (rhs_get "f")).
-  Proof.
-    apply stmt_well_typed_asgn with (ctxv_T T_int); auto.
-    apply typ_rhs_get; auto.
-  Qed.
-
-  (** useful tactics and lemmas *)
-
-  Ltac lookup_cases H i j :=
-    is_eq i j; [setoid_rewrite lookup_insert in H; inv H
-               | setoid_rewrite lookup_insert_ne in H; auto].
-
-  Ltac unfold_typing :=
-    repeat (match goal with
-            | H: cn_well_typed _ _ |- _ => inv H
-            | H: task_well_typed _ _ |- _ => inv H
-            | H: stmt_well_typed _ (stmt_seq _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_asgn _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_cond _ _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_loop _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_ret _) |- _ => inv H
-            | H: typ_rhs _ _ _ |- _ => inv H
-            (* | H: match_method _ _ _ _ |- _ => inv H *)
-            end).
-
-  (* should be a theorem, but will require some assumptions on name_of/id_of and typing of futures *)
-  Lemma fresh_config_wt: forall Γ f σ,
-      fresh f σ -> config_well_typed Γ σ -> f ∉ dom Γ.
-  Proof.
-    unfold fresh, config_well_typed.
-    intros.
-    destruct (σ !! id_of f) eqn:?.
-    - specialize (id_of_well_typed _ _ _ Heqo) as FUT_WT; auto.
-      inv FUT_WT.
-      specialize (H0 _ _ Heqo).
-      specialize (id_of_consistent _ _ _ _ Heqo).
-      intro.
-      eapply H; eauto.
-    - admit.
-      (* this seems problematic *)
-  Admitted.
-
-  Lemma q_wt_remove: forall  G0 q,
-      queue_well_typed  G0 q ->
-      forall t, queue_well_typed  G0 (remove t q).
-  Proof.
-    intros*.
-    apply H.
-    multiset_solver.
-  Qed.
-
-  Lemma q_wt_add: forall  G0 q,
-      queue_well_typed  G0 q ->
-      forall t,
-        task_well_typed G0 (Some t) ->
-        queue_well_typed  G0 (add t q).
-  Proof.
-    intros*.
-    apply gmultiset_elem_of_disj_union in H1.
-    destruct H1; auto.
-    now apply gmultiset_elem_of_singleton in H1; subst.
-  Qed.
-
-  Lemma G_vdash_union: forall Γ σ σ',
-      G_vdash_s Γ σ ->
-      (* somewhat surprisingly we do not need σ' because map_union prefers the left*)
-      (* G_vdash_s Γ σ' -> *)
-      G_vdash_s Γ (union σ σ').
-  Proof.
-    intros*.
-    apply H in H0.
-    destruct H0 as (?t & LU & TYP).
-    exists t.
-    split; simp; auto.
-  Qed.
-
-  (* this is a problem: well-typing of tasks is not closed under extensions *)
-  (* Fact subG_task_wt : exists Γ1 Γ2 t, *)
-  (*     Γ1 ⊆ Γ2 /\ task_well_typed  Γ1 t /\ ~ task_well_typed  Γ2 t. *)
-  (* Proof. *)
-  (*   exists ∅, (<["x":=ctxv_T T_bool]> ∅), (Some (tsk stmt_skip (<["x":=t_int Z0]> ∅))). *)
-  (*   splits. *)
-  (*   - now apply insert_subseteq. *)
-  (*   - econstructor. *)
-  (*     + intros*. *)
-  (*       inv H. *)
-  (*     + constructor. *)
-  (*   - inv 1. *)
-  (*     pose proof H3 "x" (ctxv_T T_bool) as (?t' & ? & ?); auto. *)
-  (*     simpl in H0. *)
-  (*     inv H0. *)
-  (* Qed. *)
-
-  Lemma subG_typ_es: forall G1 G2 es Ts,
-      subseteq G1 G2 -> typ_es G1 es Ts -> typ_es G2 es Ts.
-  Proof.
-    induction es; destruct Ts; auto; intros.
-    autorewrite with typ_es in *.
-    destruct H0.
-    split; auto.
-    eapply subG_type; eauto.
-  Qed.
-
-  Lemma subG_typ_rhs: forall G1 G2 r T0,
-      subseteq G1 G2 -> typ_rhs G1 r T0 -> typ_rhs G2 r T0.
-  Proof.
-    intros.
-    inv H0.
-    - econstructor.
-      eapply subG_type; eauto.
-    - econstructor; eauto.
-      eapply subG_typ_es; eauto.
-    - econstructor.
-      eapply lookup_weaken; eauto.
-  Qed.
-
-  Lemma subG_stmt_wt: forall G1 G2 st,
-      subseteq G1 G2 -> stmt_well_typed G1 st -> stmt_well_typed G2 st.
-  Proof.
-    intros.
-    induction H0; eauto;
-      try (now econstructor; eauto).
-    - econstructor.
-      + eapply lookup_weaken; eauto.
-      + eapply subG_typ_rhs; eauto.
-    - econstructor; eauto.
-      eapply subG_type; eauto.
-    - econstructor; eauto.
-      eapply subG_type; eauto.
-    - econstructor.
-      + eapply subG_type; eauto.
-      + eapply lookup_weaken; eauto.
-  Qed.
-
-  Lemma subG_task_wt : forall Γ1 Γ2 t,
-      Γ1 ⊆ Γ2 -> task_well_typed  Γ1 t -> task_well_typed  Γ2 t.
-  Proof.
-    intros.
-    destruct t.
-    - destruct t.
-      constructor.
-      inv H0.
-      eapply subG_stmt_wt; eauto.
-    - constructor.
-  Qed.
-
-  Lemma subG_queue_wt : forall Γ1 Γ2 q,
-      Γ1 ⊆ Γ2 -> queue_well_typed  Γ1 q -> queue_well_typed  Γ2 q.
-  Proof.
-    intros*.
-    eapply subG_task_wt; eauto.
-  Qed.
-
-  Lemma fresh_extend_wt: forall Γ σ f,
-      config_well_typed Γ σ ->
-      fresh f σ ->
-      forall T_,
-        config_well_typed (<[f:=T_]> Γ) σ.
-  Proof.
-    intros.
-    intros i ob LUi.
-    remember (id_of f) as fi.
-    is_eq i fi; subst.
-    - pose proof id_of_well_typed _ _ _ LUi as FUT.
-      inv FUT.
-      pose proof H0 _ _ _ LUi.
-      pose proof id_of_consistent _ _ _ _ LUi as <- .
-      contradiction.
-    - epose proof H i ob LUi.
-      destruct ob.
-      + enough (diff : f <> f0).
-        {
-        destruct v.
-        - inv H1.
-          econstructor; auto.
-          + setoid_rewrite lookup_insert_ne; eauto.
-          + inv H6; constructor.
-        - inv H1.
-          econstructor.
-          setoid_rewrite lookup_insert_ne; eauto.
-        }
-        intro.
-        replace i with (id_of (name_of i)) in *
-            by apply id_of_name_of.
-        pose proof id_of_consistent _ _ _ _ LUi.
-        subst.
-        contradiction.
-      + admit.
-      (* adding a future to the context does not impact typing of an object *)
-      + admit.
-        (* for invocations it is less obvious *)
-  Admitted.
-
-  Lemma bind_wt: forall m Ts T CL vs f tsk,
-      match_method m Ts T CL ->
-      bind m vs f CL = tsk ->
-      forall Γ,
-        Γ !! f = Some (ctxv_fut T) ->
-        typ_es Γ (map e_t vs) Ts ->
-        task_well_typed Γ tsk.
-  Proof.
-  Admitted.
-
-  Lemma insert_lookup_ne_extend: forall Γ i j T_ l,
-      i <> j ->
-      extend_G (<[j:=T_]> Γ) l !! i = extend_G Γ l !! i.
-  Proof.
-    induction l; intros; simpl.
-    - now apply lookup_insert_ne.
-    - unfold add_G; destruct a; simpl.
-      is_eq i x.
-      + now setoid_rewrite lookup_insert.
-      + setoid_rewrite lookup_insert_ne; eauto.
-  Qed.
-
-  Definition CL_well_typed: G -> CL -> Prop := fun _ _ => True. (*TODO: implement*)
-
-  Lemma CL_wt_fields_fresh: forall Γ C,
-      CL_well_typed Γ C ->
-      Forall (λ '(_, x), x ∉ dom Γ) (get_fields C).
-  Admitted.
-  (* arguably too strong, we only really need them to agree *)
-  (* replace subG_extend with a weaker version *)
-
-  Lemma CL_wt_add_f: forall Γ C (f:f) T,
-      CL_well_typed Γ C ->
-      CL_well_typed (<[f:=T]> Γ) C.
-  Admitted.
-
-  Lemma Forall_typ_F_extension: forall Γ Fs Cl,
-      Forall (typ_F Γ) Fs ->
-      Forall (CL_well_typed Γ) Cs ->
-      In Cl Cs ->
-      Forall (typ_F (extend_G Γ (get_fields Cl))) Fs.
-  Admitted.
-
-  Theorem type_preservation : forall (Γ: G),
-      Forall (typ_F Γ) Fs ->
-      Forall (CL_well_typed Γ) Cs ->
-      forall σ σ',
-        config_well_typed Γ σ ->
-        stmt_step Cs Fs id_of σ σ' ->
-        exists Γ', Γ ⊆ Γ' /\ config_well_typed Γ' σ'.
-  Proof.
-    intros Γ TYP_Fs TYP_Cs σ σ' WT STEP.
-    inv STEP.
-    - exists Γ; split; auto.
-      intros*.
-      lookup_cases H1 i i0.
-      + specialize (WT _ _ H0).
-        unfold_typing.
-        destruct p.
-        econstructor; eauto.
-        now apply q_wt_remove.
-      + eapply WT;eauto.
-
-    - destruct H0 as [sf ?].
-      pose proof WT as Conf_wt.
-      specialize (WT _ _ H1).
-      unfold_typing.
-      epose proof type_preservation _ _ _ _ _ _ _ _ _ H4 H0
-        as (?Γ & ?SUB & ? & ?TYP_E).
-      (* are tasks actually well-typed under this extension? *)
-      eexists.
-      split; eauto.
-      intros*.
-      lookup_cases H3 i i0.
-      + econstructor; eauto.
-        econstructor; eauto.
-      + eapply Conf_wt; eauto.
-
-    - destruct H0 as [sf ?].
-      pose proof WT as Conf_wt.
-      specialize (WT _ _ H1).
-      unfold_typing.
-      epose proof type_preservation _ _ _ _ _ _ _ _ _ H4 H0
-        as (?Γ & ?SUB & ? & ?TYP_E).
-      exists Γ0.
-      split.
-      + eapply extend_subG_2; eauto.
-        apply CL_wt_fields_fresh.
-        eapply Forall_forall; eauto.
-        eapply get_class_decl_some; eauto.
-      + intros*.
-        lookup_cases H3 o i.
-        * assert (extend_G Γ (get_fields Cl) ⊆ extend_G Γ0 (get_fields Cl)). {
-             eapply extend_subG.
-             eapply extend_subG_2; eauto.
-             apply CL_wt_fields_fresh.
-             eapply Forall_forall; eauto.
-             eapply get_class_decl_some; eauto.
-            }
-          econstructor; eauto.
-          -- eapply subG_queue_wt; eauto.
-          -- constructor.
-             eapply subG_stmt_wt; eauto.
-          -- admit. (* here we are lost without consistency of a *)
-        * admit. (* we need cn_well_typed closed under extensions *)
-
-    (* the trivial cases (ifs, skips, loops) are very similar*)
-    (* TODO: automate *)
-    - pose proof WT as Conf_wt.
-      specialize (WT _ _ H0).
-      unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H1 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof WT as Conf_wt.
-      specialize (WT _ _ H0).
-      unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H1 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof WT as Conf_wt.
-      specialize (WT _ _ H).
-      unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H0 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof WT as Conf_wt.
-      specialize (WT _ _ H).
-      unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H0 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof WT as Conf_wt.
-      specialize (WT _ _ H).
-      unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H0 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof WT as Conf_wt.
-      specialize (WT _ _ H2).
-      unfold_typing.
-      pose proof H16 as Method_wt.
-      inv H16.
-      destruct method.
-      autorewrite with get_type get_params in *.
-      epose proof type_preservation_eval_list _ _ _ _ _ _ _ H13 H1 as TYP_ARGS.
-      exists (<[f:=ctxv_fut T_5]> Γ).
-      split.
-      + apply subG_add; auto.
-        apply not_elem_of_dom.
-        eapply fresh_config_wt; eauto.
-      + intros*.
-        lookup_cases H4 oi i0.
-        * econstructor; eauto.
-          -- eapply subG_queue_wt; last apply H10.
-             eapply extend_subG.
-             apply subG_add; auto.
-             apply not_elem_of_dom_1.
-             eapply fresh_config_wt; eauto.
-          -- constructor.
-             econstructor.
-             ++ econstructor; eauto.
-                ** rewrite insert_lookup_ne_extend; eauto.
-                ** econstructor.
-                   eapply lookup_weaken with (<[f:=ctxv_fut T_5]> Γ).
-                   --- now setoid_rewrite lookup_insert.
-                   --- apply subG_extend.
-                       apply CL_wt_fields_fresh.
-                       apply CL_wt_add_f.
-                       eapply Forall_forall; eauto.
-                       eapply get_class_decl_some; eauto.
-             ++ eapply subG_stmt_wt; last apply H9.
-                eapply extend_subG.
-                apply subG_add; auto.
-                apply not_elem_of_dom_1.
-                eapply fresh_config_wt; eauto.
-          -- admit. (* should follow from freshness *)
-
-        * lookup_cases H4 i i0.
-          -- econstructor; eauto.
-             ++ apply lookup_insert.
-             ++ eapply typ_term_list_invariant; eauto.
-          -- set (fi:=id_of f).
-             is_eq fi i0; subst fi.
-             ++ setoid_rewrite lookup_insert in H4.
-                inv H4.
-                econstructor.
-                apply lookup_insert.
-             ++ setoid_rewrite lookup_insert_ne in H4; auto.
-                eapply fresh_extend_wt; eauto.
-
-    - pose proof WT _ _ H0 as fut_well_typed.
-      pose proof WT _ _ H1 as ob_well_typed.
-      exists Γ; split; auto.
-      intros*.
-      unfold_typing.
-      lookup_cases H3 o i.
-      + econstructor; eauto.
-        econstructor.
-      + lookup_cases H3 fi i.
-        * econstructor; eauto.
-          epose proof type_preservation_eval _ _ _ _ _ _ _ H5 H.
-          enough (T0 = T) by (subst; inv H3; constructor).
-          (* now we have a problem since the local state is not required to be consistent *)
-          (* pose proof (H15 _ _ H5) as (?t & ? & ?); simp. *)
-          (* inv H1; inv H9. *)
-          admit.
-        * eapply WT; eauto.
-
-    - pose proof WT _ _ H as fut_well_typed.
-      pose proof WT _ _ H0 as ob_well_typed.
-      exists Γ; split; auto.
-      intros*.
-      unfold_typing.
-      lookup_cases H1 o i.
-      + repeat (econstructor; eauto).
-        enough (T1 = T) by (subst; eapply typ_term_invariant; eauto).
-        eapply lookup_weaken with (m2:=extend_G Γ (get_fields Cl)) in H5.
-        now simp.
-        apply subG_extend.
-        apply CL_wt_fields_fresh.
-        eapply Forall_forall; eauto.
-        eapply get_class_decl_some; eauto.
-      + eapply WT; eauto.
-
-    - pose proof WT _ _ H as ob_well_typed.
-      pose proof WT _ _ H0 as inv_well_typed.
-      exists Γ; split; auto.
-      intros*.
-      unfold_typing.
-      + lookup_cases H2 oi i0.
-        * repeat (econstructor; eauto).
-          apply q_wt_add; auto.
-          replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
-          eapply bind_wt; eauto.
-          -- apply lookup_weaken with Γ; auto.
-             apply subG_extend.
-             apply CL_wt_fields_fresh.
-             eapply Forall_forall; eauto.
-             eapply get_class_decl_some; eauto.
-          -- eapply subG_typ_es; last apply H10.
-             apply subG_extend.
-             apply CL_wt_fields_fresh.
-             eapply Forall_forall; eauto.
-             eapply get_class_decl_some; eauto.
-        * is_eq i i0.
-          -- exfalso.
-             setoid_rewrite (lookup_delete σ i) in H2.
-             inv H2.
-          -- setoid_rewrite lookup_delete_ne in H2; auto.
-             eapply WT; eauto.
-      + lookup_cases H2 oi i0.
-        * repeat (econstructor; eauto).
-          apply q_wt_add; auto.
-          replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
-          eapply bind_wt; eauto.
-          -- apply lookup_weaken with Γ; auto.
-             apply subG_extend.
-             apply CL_wt_fields_fresh.
-             eapply Forall_forall; eauto.
-             eapply get_class_decl_some; eauto.
-          -- eapply subG_typ_es; last apply H10.
-             apply subG_extend.
-             apply CL_wt_fields_fresh.
-             eapply Forall_forall; eauto.
-             eapply get_class_decl_some; eauto.
-
-        * is_eq i i0.
-          -- exfalso.
-             setoid_rewrite (lookup_delete σ i) in H2.
-             inv H2.
-          -- setoid_rewrite lookup_delete_ne in H2; auto.
-             eapply WT; eauto.
-
-             Unshelve.
-             all: try eauto.
-             all: try (now apply G_vdash_union).
-             all: apply Forall_typ_F_extension; auto;
-               eapply get_class_decl_some; eauto.
-  Admitted.
-End Typing.
-(*TODO: labels + traces? *)
+Equations get_class_name (CL0:CL): C := {get_class_name (class name _ _) := name}.
+Equations get_fields (CL0:CL): list (T*x) := {get_fields (class _ fields _) := fields}.
+Equations get_methods (CL0:CL): list M := {get_methods (class _ _ methods) := methods}.
+
+Equations get_params (_:M): list (T*x) := {get_params (M_m _ _ params _ _ ) := params}.
+Equations get_type (_:M): T := {get_type (M_m type _ _ _ _ ) := type}.
+
+Definition queue := (gmultiset task).
+
+Inductive cn: Type :=
+| cn_future (f0:f) (v:option t)
+| cn_object (C0:C) (a:s) (p:option task) (q: queue)
+| cn_invoc (o0:o) (f0:f) (m0:m) (vs: list t).
+
+Variant is_fut: cn -> Prop := is_fut_intro: forall f v, is_fut (cn_future f v).
+
+Definition config := (natmap cn).
+Definition add (p:task) (q:queue) := (q ⊎ {[+ p +]}).
+Definition remove (p:task) (q:queue) := (q ∖ {[+ p +]}).
+Equations get_method_decl (m0:m) (l: list M) : option M := {
+    get_method_decl _ [] := None ;
+    get_method_decl m ((M_m T m' params decl body)::Ms) :=
+      if decide (m = m') then Some (M_m T m' params decl body) else get_method_decl m Ms
+  }.
+
+Equations get_class_decl (c:C) (l: list CL) : option CL := {
+    get_class_decl _ [] := None ;
+    get_class_decl c ((class name fields methods)::Cs) :=
+      if decide (c = name) then Some (class name fields methods) else get_class_decl c Cs
+  }.
+
+Lemma get_class_decl_some: forall c l C,
+    get_class_decl c l = Some C -> In C l.
+Proof.
+  induction l; intros; try (now inv H).
+  destruct a.
+  autorewrite with get_class_decl in *.
+  case_decide; inv H.
+  + now left.
+  + right; auto.
+Qed.
+
+Equations bind_params_aux (s0:s) (vs: list t) (params: list (T*x)): s := {
+    bind_params_aux s0 [] _ := s0;
+    bind_params_aux s0 _ [] := s0;
+    bind_params_aux s0 (v::vs) ((_,x)::Txs) := insert x v (bind_params_aux s0 vs Txs)
+  }.
+
+Definition bind_params := bind_params_aux empty.
+
+Equations bind (m0:m) (vs: list t) (f0:f) (CL0:CL) : option task := {
+    bind m vs f (class n params m_list) :=
+      match get_method_decl m m_list with
+      | None => None
+      | Some (M_m T m' params decl body) =>
+          Some (tsk body (bind_params vs params))
+      end
+  }.
+
+Definition eval (Fs: list F) (s0:s) (e0:e) (v:t): Prop :=
+  exists sf, (rtc (reduce Fs)) (e0, s0) (e_t v, sf).
+
+Equations eval_list (Fs: list F) (s0:s) (es: list e) (vs: list t): Prop := {
+    eval_list _ _ [] [] := True;
+    eval_list Fs s0 (e::es) (v::vs) := eval Fs s0 e v /\ eval_list Fs s0 es vs;
+    eval_list _ _ _ _ := False
+  }.
+
+Definition destiny: f := "destiny"%string.
+
+Definition fresh (f0:f) (σ:config) : Prop := forall i f v, σ !! i = Some (cn_future f v) -> f <> f0.
+
+Inductive stmt_step {Fs: list F}: config -> config -> Prop :=
+| step_activate: forall σ p q i a C,
+    p ∈ q ->
+    σ !! i = Some (cn_object C a None q) ->
+    stmt_step σ (<[i:=(cn_object C a (Some p) (remove p q))]> σ)
+
+| step_asgn1: forall σ i a C l x e s q v,
+    x ∈ dom l ->
+    eval Fs (union a l) e v ->
+    σ !! i = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
+    stmt_step σ (<[i:=(cn_object C a (Some (tsk s (<[x:=v]> l))) q)]> σ)
+
+| step_asgn2: forall σ o a C l x e s q v,
+    x ∈ dom a ->
+    eval Fs (union a l) e v ->
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e e)) s) l)) q) ->
+    stmt_step σ (<[o:=(cn_object C (<[x:=v]> a) (Some (tsk s l)) q)]> σ)
+
+| step_cond1: forall σ o a C l e s1 s2 s q,
+    eval Fs (union a l) e (t_b true) ->
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
+    stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq s1 s) l)) q]> σ)
+
+| step_cond2: forall σ o a C l e s1 s2 s q,
+    eval Fs (union a l) e (t_b false) ->
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_cond e s1 s2) s) l)) q) ->
+    stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq s2 s) l)) q]> σ)
+
+| step_skip1: forall σ o a C l s q,
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq stmt_skip s) l)) q) ->
+    stmt_step σ (<[o:=cn_object C a (Some (tsk s l)) q]> σ)
+
+| step_skip2: forall σ o a C l q,
+    σ !! o = Some (cn_object C a (Some (tsk stmt_skip l)) q) ->
+    stmt_step σ (<[o:=cn_object C a None q]> σ)
+
+| step_while: forall σ o a C l e s1 s2 q,
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_loop e s1) s2) l)) q) ->
+    stmt_step σ (<[o:=cn_object C a (Some ( tsk (stmt_seq (stmt_cond e (stmt_seq s1 (stmt_loop e s1)) stmt_skip) s2) l)) q]> σ)
+
+| step_call: forall σ oi o' a C l q x m es vs s f i j,
+    fresh f σ ->
+    ~ i ∈ dom σ ->
+    ~ j ∈ dom σ ->
+    eval_list Fs (union a l) es vs ->
+    σ !! oi = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_invoc o' m es)) s) l)) q) ->
+    stmt_step σ (<[oi:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q]>
+                   (<[i:=cn_invoc o' f m vs]>
+                      (<[j:=cn_future f None]> σ)))
+
+| step_return: forall σ o a C l e v q f fi,
+    eval Fs (union a l) e v ->
+    σ !! fi = Some (cn_future f None) ->
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_ret e) l)) q) ->
+    l !! destiny = Some (t_fut fi) ->
+    stmt_step σ (<[o:=cn_object C a None q]>
+                   (<[fi:=cn_future f (Some v)]> σ))
+
+| step_read: forall σ o a C l x s v q f fi,
+    σ !! fi = Some (cn_future f (Some v)) ->
+    σ !! o = Some (cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_get f)) s) l)) q) ->
+    stmt_step σ (<[o:=cn_object C a (Some (tsk (stmt_seq (stmt_asgn x (rhs_e (e_t v))) s) l)) q]> σ)
+
+| step_load: forall σ o oi i a p p' q f m vs C CL,
+    σ !! oi = Some (cn_object C a p q) ->
+    σ !! i = Some (cn_invoc o f m vs) ->
+    get_class_name CL = C ->
+    bind m vs f CL = Some p' ->
+    stmt_step σ (<[oi:=cn_object C a p (add p' q)]> (delete i σ))
+.

--- a/theories/abs_imp.v
+++ b/theories/abs_imp.v
@@ -10,6 +10,7 @@ Section Semantics.
   Context
       (Cs: list CL)
       (Fs: list F)
+      (*name_of should probably be partial to account for non-future ids *)
       (name_of: id -> f)
       (id_of: f -> id)
   .
@@ -28,6 +29,8 @@ Section Semantics.
   | cn_object (C0:C) (a:s) (p:option task) (q: queue)
   | cn_invoc (o0:o) (f0:f) (m0:m) (vs: list t).
 
+  Variant is_fut: cn -> Prop := is_fut_intro: forall f v, is_fut (cn_future f v).
+
   Definition config := (natmap cn).
   Definition add (p:task) (q:queue) := (q ⊎ {[+ p +]}).
   Definition remove (p:task) (q:queue) := (q ∖ {[+ p +]}).
@@ -45,7 +48,17 @@ Section Semantics.
         if String.eqb c name then Some (class name fields methods) else get_class_decl c Cs
     }.
 
-  #[global] Instance elem_of_list_CL: ElemOf C (list CL) := fun c Cs => get_class_decl c Cs <> None.
+  Lemma get_class_decl_some: forall c l C,
+      get_class_decl c l = Some C -> In C l.
+  Proof.
+    induction l; intros; try (now inv H).
+    destruct a.
+    autorewrite with get_class_decl in *.
+    destruct (c =? C5)%string.
+    + inv H.
+      now left.
+    + right; auto.
+  Qed.
 
   Equations bind_params_aux (s0:s) (vs: list t) (params: list (T*x)): s := {
       bind_params_aux s0 [] _ := s0;
@@ -155,243 +168,17 @@ Section Typing.
   Context
       (Cs: list CL)
       (Fs: list F)
+      (*name_of should probably be partial to account for non-future ids *)
       (name_of: id -> f)
       (id_of: f -> id)
       (class_of: o -> C)
   .
 
   Hypothesis (vars_fs_distinct: forall (x_:x) (fn:fc), x_ <> fn).
-
-  Equations typ_es: G -> list e -> list T -> Prop := {
-      typ_es _ [] [] := True ;
-      typ_es Γ (e::es) (T::Ts) := typ_e Γ e T /\ typ_es Γ es Ts ;
-      typ_es _ _ _ := False
-    }.
-
-  Lemma type_preservation_eval: forall Γ,
-      Forall (typ_F Γ) Fs ->
-      forall σ, G_vdash_s Γ σ ->
-           forall e0 e1 T0,
-             typ_e Γ e0 T0 ->
-             eval Fs σ e0 e1 ->
-             typ_e Γ (e_t e1) T0.
-  Proof.
-    intros.
-    destruct H2 as [σ' COMP].
-    pose proof type_preservation vars_fs_distinct  _ _ _ H0 H _ _ _ H1 COMP
-      as (Γ' & SUB & VDASH & TYP).
-    now inv TYP; constructor.
-  Qed.
-
-  Lemma type_preservation_eval_list: forall Γ,
-      Forall (typ_F Γ) Fs ->
-      forall σ, G_vdash_s Γ σ ->
-        forall es vs Ts,
-          typ_es Γ es Ts ->
-          eval_list Fs σ es vs ->
-          typ_es Γ (map e_t vs) Ts.
-  Proof.
-    induction es; intros;
-      destruct vs;
-      destruct Ts;
-      cbn;
-      autorewrite with typ_es eval_list in *;
-      try intuition.
-    eapply type_preservation_eval; eauto.
-  Qed.
-
-  Definition add_G (Γ:G) (Tx:T*x): G := <[Tx.2:=ctxv_T Tx.1]> Γ.
-  Definition extend_G (Γ:G) (l:list (T*x)): G := foldr (flip add_G) Γ l.
-
-  Variant match_method: m -> list T -> T -> CL -> Prop :=
-    match_intro: forall m method Cl,
-        get_method_decl m (get_methods Cl) = Some method ->
-        match_method m (map fst (get_params method)) (get_type method) Cl.
-
-  Variant typ_rhs: G -> rhs -> ctxv -> Prop :=
-    | typ_rhs_e: forall Γ e T,
-        typ_e Γ e T ->
-        typ_rhs Γ (rhs_e e) (ctxv_T T)
-    | typ_rhs_invoc: forall Γ m o es Cl Ts T,
-        typ_es Γ es Ts ->
-        get_class_decl (class_of o) Cs = Some Cl ->
-        match_method m Ts T Cl ->
-        typ_rhs Γ (rhs_invoc o m es) (ctxv_fut T)
-    | typ_rhs_fut: forall Γ f T,
-        Γ !! f = Some (ctxv_fut T) ->
-        typ_rhs Γ (rhs_get f) (ctxv_T T)
-  .
-
-  Inductive stmt_well_typed: G -> stmt -> Prop :=
-  | typ_stmt_seq: forall G s1 s2,
-      stmt_well_typed G s1 ->
-      stmt_well_typed G s2 ->
-      stmt_well_typed G (stmt_seq s1 s2)
-
-  | stmt_well_typed_skip: forall G,
-      stmt_well_typed G stmt_skip
-
-  | stmt_well_typed_asgn: forall G x r T,
-      G !! x = Some T ->
-      typ_rhs G r T ->
-      stmt_well_typed G (stmt_asgn x r)
-
-  | stmt_well_typed_cond: forall G b s1 s2,
-      typ_e G b T_bool ->
-      stmt_well_typed G s1 ->
-      stmt_well_typed G s2 ->
-      stmt_well_typed G (stmt_cond b s1 s2)
-
-  | stmt_well_typed_loop: forall G b s,
-      typ_e G b T_bool ->
-      stmt_well_typed G s ->
-      stmt_well_typed G (stmt_loop b s)
-
-  | stmt_well_typed_return: forall G e T,
-      typ_e G e T ->
-      G !! destiny = Some (ctxv_fut T) ->
-      stmt_well_typed G (stmt_ret e)
-  .
-
-  Variant task_well_typed: G -> option task -> Prop :=
-    | task_wt_idle: forall Γ, task_well_typed Γ None
-    | task_wt: forall Γ stmt l,
-        (* this differs from the paper since we do not treat l as a typed list *)
-        G_vdash_s Γ l ->
-        stmt_well_typed Γ stmt ->
-        task_well_typed Γ (Some (tsk stmt l))
-  .
-
-  Definition queue_well_typed (Γ:G) (q:queue) := forall t, t ∈ q -> task_well_typed Γ (Some t).
-
-  Variant cn_well_typed: G -> cn -> Prop :=
-    | ob_wt: forall Γ c Cl a p q fields,
-        (* The paper also checks fields(Γ(o)), but we would need another case for ctxv *)
-        get_class_decl c Cs = Some Cl ->
-        get_fields Cl = fields ->
-        queue_well_typed (extend_G Γ fields) q ->
-        task_well_typed (extend_G Γ fields) p ->
-        G_vdash_s (extend_G Γ fields) a ->
-        cn_well_typed Γ (cn_object c a p q)
-    | inv_wt: forall Γ o f T Ts m vs Cl,
-        Γ !! f = Some (ctxv_fut T) ->
-        typ_es Γ (map e_t vs) Ts ->
-        get_class_decl (class_of o) Cs = Some Cl ->
-        match_method m Ts T Cl ->
-        cn_well_typed Γ (cn_invoc o f m vs)
-    | fut_wt_none: forall G f T,
-        G !! f = Some (ctxv_fut T) ->
-        cn_well_typed  G (cn_future f None)
-    | fut_wt_some: forall G f t T,
-        G !! f = Some (ctxv_fut T) ->
-        typ_e G (e_t t) T ->
-        cn_well_typed  G (cn_future f (Some t))
-  .
-  Definition config_well_typed (G0:G) (conf: config) :=
-    forall i ob, conf !! i = Some ob -> cn_well_typed G0 ob.
-
-  (** useful tactics and lemmas *)
-
-  Ltac lookup_cases H i j :=
-    is_eq i j; [setoid_rewrite lookup_insert in H; inv H
-               | setoid_rewrite lookup_insert_ne in H; auto].
-
-  Ltac unfold_typing :=
-    repeat (match goal with
-            | H: cn_well_typed _ _ |- _ => inv H
-            | H: task_well_typed _ _ |- _ => inv H
-            | H: stmt_well_typed _ (stmt_seq _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_asgn _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_cond _ _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_loop _ _) |- _ => inv H
-            | H: stmt_well_typed _ (stmt_ret _) |- _ => inv H
-            | H: typ_rhs _ _ _ |- _ => inv H
-            (* | H: match_method _ _ _ _ |- _ => inv H *)
-            end).
-
-  (* should be a theorem, but will require some assumptions on name_of/id_of and typing of futures *)
   Hypothesis id_of_consistent: forall (σ:config) f f' v, σ !! (id_of f) = Some (cn_future f' v) -> f = f'.
-  Variant is_fut: cn -> Prop := is_fut_intro: forall f v, is_fut (cn_future f v).
   Hypothesis id_of_well_typed: forall (σ:config) f c, σ !! (id_of f) = Some c -> is_fut c.
-
-  Lemma fresh_config_wt: forall Γ f σ,
-      fresh f σ -> config_well_typed Γ σ -> f ∉ dom Γ.
-  Proof.
-    unfold fresh, config_well_typed.
-    intros.
-    destruct (σ !! id_of f) eqn:?.
-    - specialize (id_of_well_typed _ _ _ Heqo) as FUT_WT; auto.
-      inv FUT_WT.
-      specialize (H0 _ _ Heqo).
-      specialize (id_of_consistent _ _ _ _ Heqo).
-      intro.
-      eapply H; eauto.
-    - admit.
-      (* this seems problematic *)
-  Admitted.
-
-  Lemma subG_extend: forall Γ l,
-      Forall (fun '(_, x) => x ∉ dom Γ) l ->
-      Γ ⊆ extend_G Γ l.
-  Proof.
-    induction l; intros; auto.
-    destruct a; simpl in *.
-    inv H.
-    eapply subG_add; auto.
-    simpl.
-    now apply not_elem_of_dom.
-  Qed.
-
-  Lemma q_wt_remove: forall  G0 q,
-      queue_well_typed  G0 q ->
-      forall t, queue_well_typed  G0 (remove t q).
-  Proof.
-    intros*.
-    apply H.
-    multiset_solver.
-  Qed.
-
-  Lemma q_wt_add: forall  G0 q,
-      queue_well_typed  G0 q ->
-      forall t,
-        task_well_typed G0 (Some t) ->
-        queue_well_typed  G0 (add t q).
-  Proof.
-    intros*.
-    apply gmultiset_elem_of_disj_union in H1.
-    destruct H1; auto.
-    now apply gmultiset_elem_of_singleton in H1; subst.
-  Qed.
-
-  Lemma G_vdash_union: forall Γ σ σ',
-      G_vdash_s Γ σ ->
-      (* somewhat surprisingly we do not need σ' because map_union prefers the left*)
-      (* G_vdash_s Γ σ' -> *)
-      G_vdash_s Γ (union σ σ').
-  Proof.
-    intros*.
-    apply H in H0.
-    destruct H0 as (?t & LU & TYP).
-    exists t.
-    split; simp; auto.
-  Qed.
-
-  (* this is a problem: well-typing of tasks is not closed under extensions *)
-  Fact subG_task_wt : exists Γ1 Γ2 t,
-      Γ1 ⊆ Γ2 /\ task_well_typed  Γ1 t /\ ~ task_well_typed  Γ2 t.
-  Proof.
-    exists ∅, (<["x":=ctxv_T T_bool]> ∅), (Some (tsk stmt_skip (<["x":=t_int Z0]> ∅))).
-    splits.
-    - now apply insert_subseteq.
-    - econstructor.
-      + intros*.
-        inv H.
-      + constructor.
-    - inv 1.
-      pose proof H3 "x" (ctxv_T T_bool) as (?t' & ? & ?); auto.
-      simpl in H0.
-      inv H0.
-  Qed.
+  Hypothesis id_of_name_of: forall i, id_of (name_of i) = i.
+  Hypothesis name_of_id_of: forall f, name_of (id_of f) = f.
 
   (* this substitution and subsequent well-typing is not currently used *)
   (* I thought I might use it, and then didn't, but may be useful later? *)
@@ -437,6 +224,325 @@ Section Typing.
     inv H; constructor.
   Qed.
 
+  Equations typ_es: G -> list e -> list T -> Prop := {
+      typ_es _ [] [] := True ;
+      typ_es Γ (e::es) (T::Ts) := typ_e Γ e T /\ typ_es Γ es Ts ;
+      typ_es _ _ _ := False
+    }.
+
+  Lemma typ_term_invariant: forall Γ v T,
+      typ_e Γ (e_t v) T ->
+      forall Γ',
+        typ_e Γ' (e_t v) T.
+  Proof.
+    intros.
+    inv H; constructor.
+  Qed.
+
+  Lemma typ_term_list_invariant: forall Γ vs Ts,
+      typ_es Γ (map e_t vs) Ts ->
+      forall Γ',
+        typ_es Γ' (map e_t vs) Ts.
+    Proof.
+      induction vs; destruct Ts; intros; auto.
+      simpl in *.
+      autorewrite with typ_es in *.
+      destruct H.
+      split; auto.
+      eapply typ_term_invariant; eauto.
+    Qed.
+
+  Lemma type_preservation_eval: forall Γ,
+      Forall (typ_F Γ) Fs ->
+      forall σ, G_vdash_s Γ σ ->
+           forall e0 e1 T0,
+             typ_e Γ e0 T0 ->
+             eval Fs σ e0 e1 ->
+             typ_e Γ (e_t e1) T0.
+  Proof.
+    intros.
+    destruct H2 as [σ' COMP].
+    pose proof type_preservation vars_fs_distinct  _ _ _ H0 H _ _ _ H1 COMP
+      as (Γ' & SUB & VDASH & TYP).
+    now inv TYP; constructor.
+  Qed.
+
+  Lemma type_preservation_eval_list: forall Γ,
+      Forall (typ_F Γ) Fs ->
+      forall σ, G_vdash_s Γ σ ->
+        forall es vs Ts,
+          typ_es Γ es Ts ->
+          eval_list Fs σ es vs ->
+          typ_es Γ (map e_t vs) Ts.
+  Proof.
+    induction es; intros;
+      destruct vs;
+      destruct Ts;
+      cbn;
+      autorewrite with typ_es eval_list in *;
+      try intuition.
+    eapply type_preservation_eval; eauto.
+  Qed.
+
+  Definition add_G (Γ:G) (Tx:T*x): G := <[Tx.2:=ctxv_T Tx.1]> Γ.
+  Definition extend_G (Γ:G) (l:list (T*x)): G := foldr (flip add_G) Γ l.
+
+  Lemma extend_subG: forall Γ1 Γ2 l,
+      Γ1 ⊆ Γ2 -> extend_G Γ1 l ⊆ extend_G Γ2 l.
+  Proof.
+    induction l; intros; auto.
+    destruct a; simpl.
+    apply insert_mono.
+    now apply IHl.
+  Qed.
+
+  Lemma subG_extend: forall Γ l,
+      Forall (fun '(_, x) => x ∉ dom Γ) l ->
+      Γ ⊆ extend_G Γ l.
+  Proof.
+    induction l; intros; auto.
+    destruct a; simpl in *.
+    inv H.
+    eapply subG_add; auto.
+    simpl.
+    now apply not_elem_of_dom.
+  Qed.
+
+  Lemma addG_subG: forall Γ1 Γ2 Tx,
+      add_G Γ1 Tx ⊆ Γ2 ->
+      Tx.2 ∉ dom Γ1 ->
+      Γ1 ⊆ Γ2.
+  Proof.
+    unfold add_G.
+    intros.
+    epose proof map_subseteq_spec _ _ as (? & _).
+    pose proof H as H'.
+    eapply H1 with (i:=Tx.2) in H; last eapply lookup_insert.
+    eapply subG_add_2 in H; eauto.
+    transitivity (<[Tx.2:=ctxv_T Tx.1]> Γ1); auto.
+    apply subG_add; auto.
+    now apply not_elem_of_dom.
+  Qed.
+
+  Lemma extend_domain: forall Γ x l,
+      x ∉ dom Γ ->
+      Forall (λ '(_, x0), x0 <> x) l ->
+      x ∉ dom (extend_G Γ l).
+  Proof.
+    induction l; intros; auto.
+    destruct a; simpl in *.
+    inv H0.
+    pose proof IHl H H4.
+    apply not_elem_of_dom.
+    setoid_rewrite lookup_insert_ne; auto.
+    now apply not_elem_of_dom.
+  Qed.
+
+  Lemma extend_subG_2: forall Γ1 Γ2 l,
+      extend_G Γ1 l ⊆ Γ2 ->
+      Forall (λ '(_, x), x ∉ dom Γ2) l ->
+      Γ1 ⊆ Γ2.
+  Proof.
+    induction l; intros; auto.
+    destruct a; simpl in *.
+    inv H0.
+    apply addG_subG in H; auto.
+    apply extend_domain; auto.
+    - eapply lookup_weaken with (i:=x) in H; last apply lookup_insert.
+      apply not_elem_of_dom in H3.
+      setoid_rewrite H3 in H.
+      inv H.
+    - apply Forall_forall.
+      intros (?&?) ? ?.
+      eapply Forall_forall in H4; eauto.
+      simpl in *; subst.
+      eapply lookup_weaken with (i:=x) in H; last apply lookup_insert.
+      apply not_elem_of_dom in H3.
+      setoid_rewrite H3 in H.
+      inv H.
+   Qed.
+
+  Variant match_method: m -> list T -> T -> CL -> Prop :=
+    match_intro: forall m method Cl,
+        get_method_decl m (get_methods Cl) = Some method ->
+        match_method m (map fst (get_params method)) (get_type method) Cl.
+
+  Variant typ_rhs: G -> rhs -> ctxv -> Prop :=
+    | typ_rhs_e: forall Γ e T,
+        typ_e Γ e T ->
+        typ_rhs Γ (rhs_e e) (ctxv_T T)
+    | typ_rhs_invoc: forall Γ m o es Cl Ts T,
+        typ_es Γ es Ts ->
+        get_class_decl (class_of o) Cs = Some Cl ->
+        match_method m Ts T Cl ->
+        typ_rhs Γ (rhs_invoc o m es) (ctxv_T T)
+    | typ_rhs_get: forall Γ f T,
+        Γ !! f = Some (ctxv_fut T) ->
+        typ_rhs Γ (rhs_get f) (ctxv_T T)
+  .
+
+  Inductive stmt_well_typed: G -> stmt -> Prop :=
+  | typ_stmt_seq: forall G s1 s2,
+      stmt_well_typed G s1 ->
+      stmt_well_typed G s2 ->
+      stmt_well_typed G (stmt_seq s1 s2)
+
+  | stmt_well_typed_skip: forall G,
+      stmt_well_typed G stmt_skip
+
+  | stmt_well_typed_asgn: forall G x r T,
+      G !! x = Some T ->
+      typ_rhs G r T ->
+      stmt_well_typed G (stmt_asgn x r)
+
+  | stmt_well_typed_cond: forall G b s1 s2,
+      typ_e G b T_bool ->
+      stmt_well_typed G s1 ->
+      stmt_well_typed G s2 ->
+      stmt_well_typed G (stmt_cond b s1 s2)
+
+  | stmt_well_typed_loop: forall G b s,
+      typ_e G b T_bool ->
+      stmt_well_typed G s ->
+      stmt_well_typed G (stmt_loop b s)
+
+  | stmt_well_typed_return: forall G e T,
+      typ_e G e T ->
+      G !! destiny = Some (ctxv_fut T) ->
+      stmt_well_typed G (stmt_ret e)
+  .
+
+  Variant task_well_typed: G -> option task -> Prop :=
+    | task_wt_idle: forall Γ, task_well_typed Γ None
+    | task_wt: forall Γ stmt l,
+        (* this differs from the paper since we do not treat l as a typed list *)
+        (* G_vdash_s Γ l -> *)
+        stmt_well_typed Γ stmt ->
+        task_well_typed Γ (Some (tsk stmt l))
+  .
+
+  Definition queue_well_typed (Γ:G) (q:queue) := forall t, t ∈ q -> task_well_typed Γ (Some t).
+
+  Variant cn_well_typed: G -> cn -> Prop :=
+    | ob_wt: forall Γ c Cl a p q fields,
+        (* The paper also checks fields(Γ(o)), but we would need another case for ctxv *)
+        get_class_decl c Cs = Some Cl ->
+        get_fields Cl = fields ->
+        queue_well_typed (extend_G Γ fields) q ->
+        task_well_typed (extend_G Γ fields) p ->
+        G_vdash_s (extend_G Γ fields) a ->
+        cn_well_typed Γ (cn_object c a p q)
+    | inv_wt: forall Γ o f T Ts m vs Cl,
+        Γ !! f = Some (ctxv_fut T) ->
+        typ_es Γ (map e_t vs) Ts ->
+        get_class_decl (class_of o) Cs = Some Cl ->
+        match_method m Ts T Cl ->
+        cn_well_typed Γ (cn_invoc o f m vs)
+    | fut_wt_none: forall G f T,
+        G !! f = Some (ctxv_fut T) ->
+        cn_well_typed  G (cn_future f None)
+    | fut_wt_some: forall G f t T,
+        G !! f = Some (ctxv_fut T) ->
+        typ_e G (e_t t) T ->
+        cn_well_typed  G (cn_future f (Some t))
+  .
+  Definition config_well_typed (G0:G) (conf: config) :=
+    forall i ob, conf !! i = Some ob -> cn_well_typed G0 ob.
+
+  Example typing_get: let Γ := (<["x":=ctxv_T T_int]> (<["f":=ctxv_fut T_int]> ∅)) in
+                      stmt_well_typed Γ (stmt_asgn "x" (rhs_get "f")).
+  Proof.
+    apply stmt_well_typed_asgn with (ctxv_T T_int); auto.
+    apply typ_rhs_get; auto.
+  Qed.
+
+  (** useful tactics and lemmas *)
+
+  Ltac lookup_cases H i j :=
+    is_eq i j; [setoid_rewrite lookup_insert in H; inv H
+               | setoid_rewrite lookup_insert_ne in H; auto].
+
+  Ltac unfold_typing :=
+    repeat (match goal with
+            | H: cn_well_typed _ _ |- _ => inv H
+            | H: task_well_typed _ _ |- _ => inv H
+            | H: stmt_well_typed _ (stmt_seq _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_asgn _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_cond _ _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_loop _ _) |- _ => inv H
+            | H: stmt_well_typed _ (stmt_ret _) |- _ => inv H
+            | H: typ_rhs _ _ _ |- _ => inv H
+            (* | H: match_method _ _ _ _ |- _ => inv H *)
+            end).
+
+  (* should be a theorem, but will require some assumptions on name_of/id_of and typing of futures *)
+  Lemma fresh_config_wt: forall Γ f σ,
+      fresh f σ -> config_well_typed Γ σ -> f ∉ dom Γ.
+  Proof.
+    unfold fresh, config_well_typed.
+    intros.
+    destruct (σ !! id_of f) eqn:?.
+    - specialize (id_of_well_typed _ _ _ Heqo) as FUT_WT; auto.
+      inv FUT_WT.
+      specialize (H0 _ _ Heqo).
+      specialize (id_of_consistent _ _ _ _ Heqo).
+      intro.
+      eapply H; eauto.
+    - admit.
+      (* this seems problematic *)
+  Admitted.
+
+  Lemma q_wt_remove: forall  G0 q,
+      queue_well_typed  G0 q ->
+      forall t, queue_well_typed  G0 (remove t q).
+  Proof.
+    intros*.
+    apply H.
+    multiset_solver.
+  Qed.
+
+  Lemma q_wt_add: forall  G0 q,
+      queue_well_typed  G0 q ->
+      forall t,
+        task_well_typed G0 (Some t) ->
+        queue_well_typed  G0 (add t q).
+  Proof.
+    intros*.
+    apply gmultiset_elem_of_disj_union in H1.
+    destruct H1; auto.
+    now apply gmultiset_elem_of_singleton in H1; subst.
+  Qed.
+
+  Lemma G_vdash_union: forall Γ σ σ',
+      G_vdash_s Γ σ ->
+      (* somewhat surprisingly we do not need σ' because map_union prefers the left*)
+      (* G_vdash_s Γ σ' -> *)
+      G_vdash_s Γ (union σ σ').
+  Proof.
+    intros*.
+    apply H in H0.
+    destruct H0 as (?t & LU & TYP).
+    exists t.
+    split; simp; auto.
+  Qed.
+
+  (* this is a problem: well-typing of tasks is not closed under extensions *)
+  (* Fact subG_task_wt : exists Γ1 Γ2 t, *)
+  (*     Γ1 ⊆ Γ2 /\ task_well_typed  Γ1 t /\ ~ task_well_typed  Γ2 t. *)
+  (* Proof. *)
+  (*   exists ∅, (<["x":=ctxv_T T_bool]> ∅), (Some (tsk stmt_skip (<["x":=t_int Z0]> ∅))). *)
+  (*   splits. *)
+  (*   - now apply insert_subseteq. *)
+  (*   - econstructor. *)
+  (*     + intros*. *)
+  (*       inv H. *)
+  (*     + constructor. *)
+  (*   - inv 1. *)
+  (*     pose proof H3 "x" (ctxv_T T_bool) as (?t' & ? & ?); auto. *)
+  (*     simpl in H0. *)
+  (*     inv H0. *)
+  (* Qed. *)
+
   Lemma subG_typ_es: forall G1 G2 es Ts,
       subseteq G1 G2 -> typ_es G1 es Ts -> typ_es G2 es Ts.
   Proof.
@@ -478,60 +584,193 @@ Section Typing.
       + eapply lookup_weaken; eauto.
   Qed.
 
+  Lemma subG_task_wt : forall Γ1 Γ2 t,
+      Γ1 ⊆ Γ2 -> task_well_typed  Γ1 t -> task_well_typed  Γ2 t.
+  Proof.
+    intros.
+    destruct t.
+    - destruct t.
+      constructor.
+      inv H0.
+      eapply subG_stmt_wt; eauto.
+    - constructor.
+  Qed.
+
+  Lemma subG_queue_wt : forall Γ1 Γ2 q,
+      Γ1 ⊆ Γ2 -> queue_well_typed  Γ1 q -> queue_well_typed  Γ2 q.
+  Proof.
+    intros*.
+    eapply subG_task_wt; eauto.
+  Qed.
+
   Lemma fresh_extend_wt: forall Γ σ f,
       config_well_typed Γ σ ->
       fresh f σ ->
       forall T_,
         config_well_typed (<[f:=T_]> Γ) σ.
   Proof.
+    intros.
+    intros i ob LUi.
+    remember (id_of f) as fi.
+    is_eq i fi; subst.
+    - pose proof id_of_well_typed _ _ _ LUi as FUT.
+      inv FUT.
+      pose proof H0 _ _ _ LUi.
+      pose proof id_of_consistent _ _ _ _ LUi as <- .
+      contradiction.
+    - epose proof H i ob LUi.
+      destruct ob.
+      + enough (diff : f <> f0).
+        {
+        destruct v.
+        - inv H1.
+          econstructor; auto.
+          + setoid_rewrite lookup_insert_ne; eauto.
+          + inv H6; constructor.
+        - inv H1.
+          econstructor.
+          setoid_rewrite lookup_insert_ne; eauto.
+        }
+        intro.
+        replace i with (id_of (name_of i)) in *
+            by apply id_of_name_of.
+        pose proof id_of_consistent _ _ _ _ LUi.
+        subst.
+        contradiction.
+      + admit.
+      (* adding a future to the context does not impact typing of an object *)
+      + admit.
+        (* for invocations it is less obvious *)
+  Admitted.
+
+  Lemma bind_wt: forall m Ts T CL vs f tsk,
+      match_method m Ts T CL ->
+      bind m vs f CL = tsk ->
+      forall Γ,
+        Γ !! f = Some (ctxv_fut T) ->
+        typ_es Γ (map e_t vs) Ts ->
+        task_well_typed Γ tsk.
+  Proof.
+  Admitted.
+
+  Lemma insert_lookup_ne_extend: forall Γ i j T_ l,
+      i <> j ->
+      extend_G (<[j:=T_]> Γ) l !! i = extend_G Γ l !! i.
+  Proof.
+    induction l; intros; simpl.
+    - now apply lookup_insert_ne.
+    - unfold add_G; destruct a; simpl.
+      is_eq i x.
+      + now setoid_rewrite lookup_insert.
+      + setoid_rewrite lookup_insert_ne; eauto.
+  Qed.
+
+  Definition CL_well_typed: G -> CL -> Prop := fun _ _ => True. (*TODO: implement*)
+
+  Lemma CL_wt_fields_fresh: forall Γ C,
+      CL_well_typed Γ C ->
+      Forall (λ '(_, x), x ∉ dom Γ) (get_fields C).
+  Admitted.
+  (* arguably too strong, we only really need them to agree *)
+  (* replace subG_extend with a weaker version *)
+
+  Lemma CL_wt_add_f: forall Γ C (f:f) T,
+      CL_well_typed Γ C ->
+      CL_well_typed (<[f:=T]> Γ) C.
+  Admitted.
+
+  Lemma Forall_typ_F_extension: forall Γ Fs Cl,
+      Forall (typ_F Γ) Fs ->
+      Forall (CL_well_typed Γ) Cs ->
+      In Cl Cs ->
+      Forall (typ_F (extend_G Γ (get_fields Cl))) Fs.
   Admitted.
 
   Theorem type_preservation : forall (Γ: G),
       Forall (typ_F Γ) Fs ->
+      Forall (CL_well_typed Γ) Cs ->
       forall σ σ',
         config_well_typed Γ σ ->
         stmt_step Cs Fs id_of σ σ' ->
         exists Γ', Γ ⊆ Γ' /\ config_well_typed Γ' σ'.
   Proof.
-    intros.
-    inv H1.
+    intros Γ TYP_Fs TYP_Cs σ σ' WT STEP.
+    inv STEP.
     - exists Γ; split; auto.
       intros*.
       lookup_cases H1 i i0.
-      + specialize (H0 _ _ H3).
+      + specialize (WT _ _ H0).
         unfold_typing.
         destruct p.
         econstructor; eauto.
         now apply q_wt_remove.
-      + eapply H0;eauto.
+      + eapply WT;eauto.
 
-    - destruct H3 as [sf ?].
-      pose proof H1 as Conf_wt.
-      specialize (H0 _ _ H4).
+    - destruct H0 as [sf ?].
+      pose proof WT as Conf_wt.
+      specialize (WT _ _ H1).
       unfold_typing.
-      epose proof type_preservation _ _ _ _ _ _ _ _ _ H5 H1
+      epose proof type_preservation _ _ _ _ _ _ _ _ _ H4 H0
         as (?Γ & ?SUB & ? & ?TYP_E).
       (* are tasks actually well-typed under this extension? *)
-      admit.
-      Unshelve.
-      + apply vars_fs_distinct.
-      + now apply G_vdash_union.
-      + apply subG_typ_F_forall with Γ; auto.
-        apply subG_extend.
-        admit. (* can we guarantee that the fields are not already in the context? *)
+      eexists.
+      split; eauto.
+      intros*.
+      lookup_cases H3 i i0.
+      + econstructor; eauto.
+        econstructor; eauto.
+      + eapply Conf_wt; eauto.
 
-    - destruct H3 as [sf ?].
-      pose proof H1 as Conf_wt.
-      specialize (H0 _ _ H4).
+    - destruct H0 as [sf ?].
+      pose proof WT as Conf_wt.
+      specialize (WT _ _ H1).
       unfold_typing.
-      epose proof type_preservation _ _ _ _ _ _ _ _ _ H5 H1
+      epose proof type_preservation _ _ _ _ _ _ _ _ _ H4 H0
         as (?Γ & ?SUB & ? & ?TYP_E).
-      admit.
+      exists Γ0.
+      split.
+      + eapply extend_subG_2; eauto.
+        apply CL_wt_fields_fresh.
+        eapply Forall_forall; eauto.
+        eapply get_class_decl_some; eauto.
+      + intros*.
+        lookup_cases H3 o i.
+        * assert (extend_G Γ (get_fields Cl) ⊆ extend_G Γ0 (get_fields Cl)). {
+             eapply extend_subG.
+             eapply extend_subG_2; eauto.
+             apply CL_wt_fields_fresh.
+             eapply Forall_forall; eauto.
+             eapply get_class_decl_some; eauto.
+            }
+          econstructor; eauto.
+          -- eapply subG_queue_wt; eauto.
+          -- constructor.
+             eapply subG_stmt_wt; eauto.
+          -- admit. (* here we are lost without consistency of a *)
+        * admit. (* we need cn_well_typed closed under extensions *)
 
     (* the trivial cases (ifs, skips, loops) are very similar*)
     (* TODO: automate *)
-    - pose proof H0 as Conf_wt.
-      specialize (H0 _ _ H3).
+    - pose proof WT as Conf_wt.
+      specialize (WT _ _ H0).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H1 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof WT as Conf_wt.
+      specialize (WT _ _ H0).
+      unfold_typing.
+      exists Γ; split; auto.
+      intros*.
+      lookup_cases H1 o i.
+      + repeat (econstructor; eauto).
+      + eapply Conf_wt; eauto.
+
+    - pose proof WT as Conf_wt.
+      specialize (WT _ _ H).
       unfold_typing.
       exists Γ; split; auto.
       intros*.
@@ -539,8 +778,8 @@ Section Typing.
       + repeat (econstructor; eauto).
       + eapply Conf_wt; eauto.
 
-    - pose proof H0 as Conf_wt.
-      specialize (H0 _ _ H3).
+    - pose proof WT as Conf_wt.
+      specialize (WT _ _ H).
       unfold_typing.
       exists Γ; split; auto.
       intros*.
@@ -548,8 +787,8 @@ Section Typing.
       + repeat (econstructor; eauto).
       + eapply Conf_wt; eauto.
 
-    - pose proof H0 as Conf_wt.
-      specialize (H0 _ _ H2).
+    - pose proof WT as Conf_wt.
+      specialize (WT _ _ H).
       unfold_typing.
       exists Γ; split; auto.
       intros*.
@@ -557,127 +796,147 @@ Section Typing.
       + repeat (econstructor; eauto).
       + eapply Conf_wt; eauto.
 
-    - pose proof H0 as Conf_wt.
-      specialize (H0 _ _ H2).
+    - pose proof WT as Conf_wt.
+      specialize (WT _ _ H2).
       unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H0 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof H0 as Conf_wt.
-      specialize (H0 _ _ H2).
-      unfold_typing.
-      exists Γ; split; auto.
-      intros*.
-      lookup_cases H0 o i.
-      + repeat (econstructor; eauto).
-      + eapply Conf_wt; eauto.
-
-    - pose proof H0 as Conf_wt.
-      specialize (H0 _ _ H5).
-      unfold_typing.
-      pose proof H18 as Method_wt.
-      inv H18.
+      pose proof H16 as Method_wt.
+      inv H16.
       destruct method.
       autorewrite with get_type get_params in *.
-      epose proof type_preservation_eval_list _ _ _ _ _ _ _ H15 H4 as TYP_ARGS.
+      epose proof type_preservation_eval_list _ _ _ _ _ _ _ H13 H1 as TYP_ARGS.
       exists (<[f:=ctxv_fut T_5]> Γ).
       split.
       + apply subG_add; auto.
         apply not_elem_of_dom.
         eapply fresh_config_wt; eauto.
       + intros*.
-        lookup_cases H1 oi i0.
+        lookup_cases H4 oi i0.
         * econstructor; eauto.
-          -- admit.
-          -- constructor; auto.
-             ++ admit.
-             ++ econstructor.
-                ** econstructor; eauto.
-                   --- admit.
-                   --- econstructor.
-                       eapply lookup_weaken with (<[f:=ctxv_fut T_5]> Γ).
-                       +++ apply lookup_insert.
-                       +++ apply subG_extend.
-                           admit.
-                ** eapply subG_stmt_wt.
-                   --- admit.
-                   --- eauto.
+          -- eapply subG_queue_wt; last apply H10.
+             eapply extend_subG.
+             apply subG_add; auto.
+             apply not_elem_of_dom_1.
+             eapply fresh_config_wt; eauto.
+          -- constructor.
+             econstructor.
+             ++ econstructor; eauto.
+                ** rewrite insert_lookup_ne_extend; eauto.
+                ** econstructor.
+                   eapply lookup_weaken with (<[f:=ctxv_fut T_5]> Γ).
+                   --- now setoid_rewrite lookup_insert.
+                   --- apply subG_extend.
+                       apply CL_wt_fields_fresh.
+                       apply CL_wt_add_f.
+                       eapply Forall_forall; eauto.
+                       eapply get_class_decl_some; eauto.
+             ++ eapply subG_stmt_wt; last apply H9.
+                eapply extend_subG.
+                apply subG_add; auto.
+                apply not_elem_of_dom_1.
+                eapply fresh_config_wt; eauto.
           -- admit. (* should follow from freshness *)
-        * lookup_cases H1 i i0.
+
+        * lookup_cases H4 i i0.
           -- econstructor; eauto.
              ++ apply lookup_insert.
-             ++ admit. (* I would like to use TYP_ARGS, but that includes the fields from the object *)
+             ++ eapply typ_term_list_invariant; eauto.
           -- set (fi:=id_of f).
              is_eq fi i0; subst fi.
-             ++ setoid_rewrite lookup_insert in H1.
-                inv H1.
+             ++ setoid_rewrite lookup_insert in H4.
+                inv H4.
                 econstructor.
                 apply lookup_insert.
-             ++ setoid_rewrite lookup_insert_ne in H1; auto.
+             ++ setoid_rewrite lookup_insert_ne in H4; auto.
                 eapply fresh_extend_wt; eauto.
 
-    - pose proof H0 _ _ H3 as fut_well_typed.
-      pose proof H0 _ _ H4 as ob_well_typed.
+    - pose proof WT _ _ H0 as fut_well_typed.
+      pose proof WT _ _ H1 as ob_well_typed.
       exists Γ; split; auto.
       intros*.
       unfold_typing.
-      lookup_cases H1 o i.
+      lookup_cases H3 o i.
       + econstructor; eauto.
         econstructor.
-      + lookup_cases H1 fi i.
+      + lookup_cases H3 fi i.
         * econstructor; eauto.
-          epose proof type_preservation_eval _ _ _ _ _ _ _ H7 H2.
-          enough (T0 = T) by (subst; inv H1; constructor).
-          pose proof (H11 _ _ H14) as (?t & ? & ?); simp.
-          inv H1; inv H9.
-        * eapply H0; eauto.
+          epose proof type_preservation_eval _ _ _ _ _ _ _ H5 H.
+          enough (T0 = T) by (subst; inv H3; constructor).
+          (* now we have a problem since the local state is not required to be consistent *)
+          (* pose proof (H15 _ _ H5) as (?t & ? & ?); simp. *)
+          (* inv H1; inv H9. *)
+          admit.
+        * eapply WT; eauto.
 
-    - pose proof H0 _ _ H2 as fut_well_typed.
-      pose proof H0 _ _ H3 as ob_well_typed.
+    - pose proof WT _ _ H as fut_well_typed.
+      pose proof WT _ _ H0 as ob_well_typed.
       exists Γ; split; auto.
       intros*.
       unfold_typing.
       lookup_cases H1 o i.
       + repeat (econstructor; eauto).
-        replace T1 with T by admit. (* follows from f ∉ fields(Cl) *)
-        eapply subG_type with Γ; auto.
+        enough (T1 = T) by (subst; eapply typ_term_invariant; eauto).
+        eapply lookup_weaken with (m2:=extend_G Γ (get_fields Cl)) in H5.
+        now simp.
         apply subG_extend.
-        admit.
-      + eapply H0; eauto.
+        apply CL_wt_fields_fresh.
+        eapply Forall_forall; eauto.
+        eapply get_class_decl_some; eauto.
+      + eapply WT; eauto.
 
-    - pose proof H0 _ _ H2 as ob_well_typed.
-      pose proof H0 _ _ H3 as inv_well_typed.
+    - pose proof WT _ _ H as ob_well_typed.
+      pose proof WT _ _ H0 as inv_well_typed.
       exists Γ; split; auto.
       intros*.
       unfold_typing.
-      + lookup_cases H1 oi i0.
+      + lookup_cases H2 oi i0.
         * repeat (econstructor; eauto).
           apply q_wt_add; auto.
-          admit. (* here we need Γ ⊢ Cl -> Γ ⊢ bind m vs f*)
+          replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
+          eapply bind_wt; eauto.
+          -- apply lookup_weaken with Γ; auto.
+             apply subG_extend.
+             apply CL_wt_fields_fresh.
+             eapply Forall_forall; eauto.
+             eapply get_class_decl_some; eauto.
+          -- eapply subG_typ_es; last apply H10.
+             apply subG_extend.
+             apply CL_wt_fields_fresh.
+             eapply Forall_forall; eauto.
+             eapply get_class_decl_some; eauto.
         * is_eq i i0.
           -- exfalso.
-             setoid_rewrite (lookup_delete σ i) in H1.
-             inv H1.
-          -- setoid_rewrite lookup_delete_ne in H1; auto.
-             eapply H0; eauto.
-      + lookup_cases H1 oi i0.
+             setoid_rewrite (lookup_delete σ i) in H2.
+             inv H2.
+          -- setoid_rewrite lookup_delete_ne in H2; auto.
+             eapply WT; eauto.
+      + lookup_cases H2 oi i0.
         * repeat (econstructor; eauto).
           apply q_wt_add; auto.
-          admit. (* here we need Γ ⊢ Cl -> Γ ⊢ bind m vs f*)
+          replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
+          eapply bind_wt; eauto.
+          -- apply lookup_weaken with Γ; auto.
+             apply subG_extend.
+             apply CL_wt_fields_fresh.
+             eapply Forall_forall; eauto.
+             eapply get_class_decl_some; eauto.
+          -- eapply subG_typ_es; last apply H10.
+             apply subG_extend.
+             apply CL_wt_fields_fresh.
+             eapply Forall_forall; eauto.
+             eapply get_class_decl_some; eauto.
+
         * is_eq i i0.
           -- exfalso.
-             setoid_rewrite (lookup_delete σ i) in H1.
-             inv H1.
-          -- setoid_rewrite lookup_delete_ne in H1; auto.
-             eapply H0; eauto.
+             setoid_rewrite (lookup_delete σ i) in H2.
+             inv H2.
+          -- setoid_rewrite lookup_delete_ne in H2; auto.
+             eapply WT; eauto.
 
              Unshelve.
              all: try eauto.
              all: try (now apply G_vdash_union).
-             (*remaining: typ_F closed under (well-typed?) extensions *)
+             all: apply Forall_typ_F_extension; auto;
+               eapply get_class_decl_some; eauto.
   Admitted.
 End Typing.
 (*TODO: labels + traces? *)

--- a/theories/abs_imperative_metatheory.v
+++ b/theories/abs_imperative_metatheory.v
@@ -399,7 +399,7 @@ Theorem type_preservation : forall (Γ: G),
     Forall (CL_well_typed Γ) Cs ->
     forall σ σ',
       config_well_typed Γ σ ->
-      stmt_step Cs Fs id_of σ σ' ->
+      @stmt_step Fs σ σ' ->
       exists Γ', Γ ⊆ Γ' /\ config_well_typed Γ' σ'.
 Proof.
   intros Γ TYP_Fs TYP_Cs σ σ' WT STEP.
@@ -505,22 +505,22 @@ Proof.
     + eapply Conf_wt; eauto.
 
   - pose proof WT as Conf_wt.
-    specialize (WT _ _ H2).
+    specialize (WT _ _ H3).
     unfold_typing.
-    pose proof H16 as Method_wt.
-    inv H16.
+    pose proof H17 as Method_wt.
+    inv H17.
     destruct method.
     autorewrite with get_type get_params in *.
-    epose proof type_preservation_eval_list _ _ _ _ _ _ _ H13 H1 as TYP_ARGS.
+    epose proof type_preservation_eval_list _ _ _ _ _ _ _ H14 H2 as TYP_ARGS.
     exists (<[f:=ctxv_fut T_5]> Γ).
     split.
     + apply subG_add; auto.
       apply not_elem_of_dom.
       eapply fresh_config_wt; eauto.
     + intros*.
-      lookup_cases H4 oi i0.
+      lookup_cases H5 oi i0.
       * econstructor; eauto.
-        -- eapply subG_queue_wt; last apply H10.
+        -- eapply subG_queue_wt; last apply H11.
             eapply extend_subG.
             apply subG_add; auto.
             apply not_elem_of_dom_1.
@@ -537,24 +537,25 @@ Proof.
                       apply CL_wt_add_f.
                       eapply Forall_forall; eauto.
                       eapply get_class_decl_some; eauto.
-            ++ eapply subG_stmt_wt; last apply H9.
+            ++ eapply subG_stmt_wt; last apply H10.
               eapply extend_subG.
               apply subG_add; auto.
               apply not_elem_of_dom_1.
               eapply fresh_config_wt; eauto.
         -- admit. (* should follow from freshness *)
 
-      * lookup_cases H4 i i0.
+      * lookup_cases H5 i i0.
         -- econstructor; eauto.
             ++ apply lookup_insert.
             ++ eapply typ_term_list_invariant; eauto.
         -- set (fi:=id_of f).
-            is_eq fi i0; subst fi.
-            ++ setoid_rewrite lookup_insert in H4.
-              inv H4.
+           replace j with (id_of f) in * by admit. (* we need id_of to be consistent with j*)
+           is_eq fi i0; subst fi.
+           ++ setoid_rewrite lookup_insert in H5.
+              inv H5.
               econstructor.
               apply lookup_insert.
-            ++ setoid_rewrite lookup_insert_ne in H4; auto.
+            ++ setoid_rewrite lookup_insert_ne in H5; auto.
               eapply fresh_extend_wt; eauto.
 
   - pose proof WT _ _ H0 as fut_well_typed.
@@ -596,7 +597,7 @@ Proof.
     exists Γ; split; auto.
     intros*.
     unfold_typing.
-    + lookup_cases H2 oi i0.
+    + lookup_cases H1 oi i0.
       * repeat (econstructor; eauto).
         apply q_wt_add; auto.
         replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
@@ -606,18 +607,18 @@ Proof.
             apply CL_wt_fields_fresh.
             eapply Forall_forall; eauto.
             eapply get_class_decl_some; eauto.
-        -- eapply subG_typ_es; last apply H10.
+        -- eapply subG_typ_es; last apply H9.
             apply subG_extend.
             apply CL_wt_fields_fresh.
             eapply Forall_forall; eauto.
             eapply get_class_decl_some; eauto.
       * is_eq i i0.
         -- exfalso.
-            setoid_rewrite (lookup_delete σ i) in H2.
-            inv H2.
-        -- setoid_rewrite lookup_delete_ne in H2; auto.
+            setoid_rewrite (lookup_delete σ i) in H1.
+            inv H1.
+        -- setoid_rewrite lookup_delete_ne in H1; auto.
             eapply WT; eauto.
-    + lookup_cases H2 oi i0.
+    + lookup_cases H1 oi i0.
       * repeat (econstructor; eauto).
         apply q_wt_add; auto.
         replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
@@ -627,7 +628,7 @@ Proof.
             apply CL_wt_fields_fresh.
             eapply Forall_forall; eauto.
             eapply get_class_decl_some; eauto.
-        -- eapply subG_typ_es; last apply H10.
+        -- eapply subG_typ_es; last apply H9.
             apply subG_extend.
             apply CL_wt_fields_fresh.
             eapply Forall_forall; eauto.
@@ -635,9 +636,9 @@ Proof.
 
       * is_eq i i0.
         -- exfalso.
-            setoid_rewrite (lookup_delete σ i) in H2.
-            inv H2.
-        -- setoid_rewrite lookup_delete_ne in H2; auto.
+            setoid_rewrite (lookup_delete σ i) in H1.
+            inv H1.
+        -- setoid_rewrite lookup_delete_ne in H1; auto.
             eapply WT; eauto.
 
             Unshelve.

--- a/theories/abs_imperative_metatheory.v
+++ b/theories/abs_imperative_metatheory.v
@@ -1,0 +1,650 @@
+From stdpp Require Import prelude strings fin_maps natmap gmap gmultiset.
+From ABS Require Import list_util abs_defs abs_util abs_functional_metatheory abs_imp.
+
+(* based on https://link.springer.com/chapter/10.1007/978-3-642-25271-6_8 *)
+Section Typing.
+Context
+  (Cs: list CL)
+    (Fs: list F)
+    (*name_of should probably be partial to account for non-future ids *)
+    (name_of: id -> f)
+    (id_of: f -> id)
+    (class_of: o -> C)
+.
+
+Hypothesis (vars_fs_distinct: forall (x_:x) (fn:fc), x_ <> fn).
+Hypothesis id_of_consistent: forall (σ:config) f f' v, σ !! (id_of f) = Some (cn_future f' v) -> f = f'.
+Hypothesis id_of_well_typed: forall (σ:config) f c, σ !! (id_of f) = Some c -> is_fut c.
+Hypothesis id_of_name_of: forall i, id_of (name_of i) = i.
+Hypothesis name_of_id_of: forall f, name_of (id_of f) = f.
+
+Lemma vdash_implies_wt: forall Γ σ,
+    G_vdash_s Γ σ ->
+    sub_well_typed Γ σ.
+Proof.
+  intros*.
+  pose proof H x_ (ctxv_T T_) H1 as (?t_ & LU & TYP).
+  autorewrite with e_subst_s.
+  now rewrite LU.
+Qed.
+
+Lemma G_vdash_union: forall Γ σ σ',
+    G_vdash_s Γ σ ->
+    (* somewhat surprisingly we do not need σ' because map_union prefers the left*)
+    (* G_vdash_s Γ σ' -> *)
+    G_vdash_s Γ (union σ σ').
+Proof.
+  intros*.
+  apply H in H0.
+  destruct H0 as (?t & LU & TYP).
+  exists t.
+  split; simp; auto.
+Qed.
+
+Lemma typ_term_invariant: forall Γ v T,
+    typ_e Γ (e_t v) T ->
+    forall Γ',
+      typ_e Γ' (e_t v) T.
+Proof.
+  intros.
+  inv H; constructor.
+Qed.
+
+Lemma typ_term_list_invariant: forall Γ vs Ts,
+    typ_es Γ (map e_t vs) Ts ->
+    forall Γ',
+      typ_es Γ' (map e_t vs) Ts.
+Proof.
+  induction vs; destruct Ts; intros; auto.
+  simpl in *.
+  autorewrite with typ_es in *.
+  destruct H.
+  split; auto.
+  eapply typ_term_invariant; eauto.
+Qed.
+
+Lemma type_preservation_eval: forall Γ,
+    Forall (typ_F Γ) Fs ->
+    forall σ, G_vdash_s Γ σ ->
+          forall e0 e1 T0,
+            typ_e Γ e0 T0 ->
+            eval Fs σ e0 e1 ->
+            typ_e Γ (e_t e1) T0.
+Proof.
+  intros.
+  destruct H2 as [σ' COMP].
+  pose proof type_preservation vars_fs_distinct  _ _ _ H0 H _ _ _ H1 COMP
+    as (Γ' & SUB & VDASH & TYP).
+  now inv TYP; constructor.
+Qed.
+
+Lemma type_preservation_eval_list: forall Γ,
+    Forall (typ_F Γ) Fs ->
+    forall σ, G_vdash_s Γ σ ->
+              forall es vs Ts,
+                typ_es Γ es Ts ->
+                eval_list Fs σ es vs ->
+                typ_es Γ (map e_t vs) Ts.
+Proof.
+  induction es; intros;
+    destruct vs;
+    destruct Ts;
+    cbn;
+    autorewrite with typ_es eval_list in *;
+    try intuition.
+  eapply type_preservation_eval; eauto.
+Qed.
+
+Variant match_method: m -> list T -> T -> CL -> Prop :=
+  match_intro: forall m method Cl,
+      get_method_decl m (get_methods Cl) = Some method ->
+      match_method m (map fst (get_params method)) (get_type method) Cl.
+
+Variant typ_rhs: G -> rhs -> ctxv -> Prop :=
+  | typ_rhs_e: forall Γ e T,
+      typ_e Γ e T ->
+      typ_rhs Γ (rhs_e e) (ctxv_T T)
+  | typ_rhs_invoc: forall Γ m o es Cl Ts T,
+      typ_es Γ es Ts ->
+      get_class_decl (class_of o) Cs = Some Cl ->
+      match_method m Ts T Cl ->
+      typ_rhs Γ (rhs_invoc o m es) (ctxv_T T)
+  | typ_rhs_get: forall Γ f T,
+      Γ !! f = Some (ctxv_fut T) ->
+      typ_rhs Γ (rhs_get f) (ctxv_T T)
+.
+
+Inductive stmt_well_typed: G -> stmt -> Prop :=
+| typ_stmt_seq: forall G s1 s2,
+    stmt_well_typed G s1 ->
+    stmt_well_typed G s2 ->
+    stmt_well_typed G (stmt_seq s1 s2)
+
+| stmt_well_typed_skip: forall G,
+    stmt_well_typed G stmt_skip
+
+| stmt_well_typed_asgn: forall G x r T,
+    G !! x = Some T ->
+    typ_rhs G r T ->
+    stmt_well_typed G (stmt_asgn x r)
+
+| stmt_well_typed_cond: forall G b s1 s2,
+    typ_e G b T_bool ->
+    stmt_well_typed G s1 ->
+    stmt_well_typed G s2 ->
+    stmt_well_typed G (stmt_cond b s1 s2)
+
+| stmt_well_typed_loop: forall G b s,
+    typ_e G b T_bool ->
+    stmt_well_typed G s ->
+    stmt_well_typed G (stmt_loop b s)
+
+| stmt_well_typed_return: forall G e T,
+    typ_e G e T ->
+    G !! destiny = Some (ctxv_fut T) ->
+    stmt_well_typed G (stmt_ret e)
+.
+
+Variant task_well_typed: G -> option task -> Prop :=
+  | task_wt_idle: forall Γ, task_well_typed Γ None
+  | task_wt: forall Γ stmt l,
+      (* this differs from the paper since we do not treat l as a typed list *)
+      (* G_vdash_s Γ l -> *)
+      stmt_well_typed Γ stmt ->
+      task_well_typed Γ (Some (tsk stmt l))
+.
+
+Definition queue_well_typed (Γ:G) (q:queue) := forall t, t ∈ q -> task_well_typed Γ (Some t).
+
+Variant cn_well_typed: G -> cn -> Prop :=
+  | ob_wt: forall Γ c Cl a p q fields,
+      (* The paper also checks fields(Γ(o)), but we would need another case for ctxv *)
+      get_class_decl c Cs = Some Cl ->
+      get_fields Cl = fields ->
+      queue_well_typed (extend_G Γ fields) q ->
+      task_well_typed (extend_G Γ fields) p ->
+      G_vdash_s (extend_G Γ fields) a ->
+      cn_well_typed Γ (cn_object c a p q)
+  | inv_wt: forall Γ o f T Ts m vs Cl,
+      Γ !! f = Some (ctxv_fut T) ->
+      typ_es Γ (map e_t vs) Ts ->
+      get_class_decl (class_of o) Cs = Some Cl ->
+      match_method m Ts T Cl ->
+      cn_well_typed Γ (cn_invoc o f m vs)
+  | fut_wt_none: forall G f T,
+      G !! f = Some (ctxv_fut T) ->
+      cn_well_typed  G (cn_future f None)
+  | fut_wt_some: forall G f t T,
+      G !! f = Some (ctxv_fut T) ->
+      typ_e G (e_t t) T ->
+      cn_well_typed  G (cn_future f (Some t))
+.
+
+Ltac unfold_typing :=
+  repeat (match goal with
+          | H: cn_well_typed _ _ |- _ => inv H
+          | H: task_well_typed _ _ |- _ => inv H
+          | H: stmt_well_typed _ (stmt_seq _ _) |- _ => inv H
+          | H: stmt_well_typed _ (stmt_asgn _ _) |- _ => inv H
+          | H: stmt_well_typed _ (stmt_cond _ _ _) |- _ => inv H
+          | H: stmt_well_typed _ (stmt_loop _ _) |- _ => inv H
+          | H: stmt_well_typed _ (stmt_ret _) |- _ => inv H
+          | H: typ_rhs _ _ _ |- _ => inv H
+          end).
+
+Definition config_well_typed (G0:G) (conf: config) :=
+  forall i ob, conf !! i = Some ob -> cn_well_typed G0 ob.
+
+(* should be a theorem, but will require some assumptions on name_of/id_of and typing of futures *)
+Lemma fresh_config_wt: forall Γ f σ,
+    fresh f σ -> config_well_typed Γ σ -> f ∉ dom Γ.
+Proof.
+  unfold fresh, config_well_typed.
+  intros.
+  destruct (σ !! id_of f) eqn:?.
+  - specialize (id_of_well_typed _ _ _ Heqo) as FUT_WT; auto.
+    inv FUT_WT.
+    specialize (H0 _ _ Heqo).
+    specialize (id_of_consistent _ _ _ _ Heqo).
+    intro.
+    eapply H; eauto.
+  - admit.
+    (* this seems problematic *)
+Admitted.
+
+Lemma q_wt_remove: forall  G0 q,
+    queue_well_typed  G0 q ->
+    forall t, queue_well_typed  G0 (remove t q).
+Proof.
+  intros*.
+  apply H.
+  multiset_solver.
+Qed.
+
+Lemma q_wt_add: forall  G0 q,
+    queue_well_typed  G0 q ->
+    forall t,
+      task_well_typed G0 (Some t) ->
+      queue_well_typed  G0 (add t q).
+Proof.
+  intros*.
+  apply gmultiset_elem_of_disj_union in H1.
+  destruct H1; auto.
+  now apply gmultiset_elem_of_singleton in H1; subst.
+Qed.
+
+(* this is a problem: well-typing of tasks is not closed under extensions *)
+(* currently commented out along with the G_vdash_part of task_well_typed *)
+(* Fact subG_task_wt : exists Γ1 Γ2 t, *)
+(*     Γ1 ⊆ Γ2 /\ task_well_typed  Γ1 t /\ ~ task_well_typed  Γ2 t. *)
+(* Proof. *)
+(*   exists ∅, (<["x":=ctxv_T T_bool]> ∅), (Some (tsk stmt_skip (<["x":=t_int Z0]> ∅))). *)
+(*   splits. *)
+(*   - now apply insert_subseteq. *)
+(*   - econstructor. *)
+(*     + intros*. *)
+(*       inv H. *)
+(*     + constructor. *)
+(*   - inv 1. *)
+(*     pose proof H3 "x" (ctxv_T T_bool) as (?t' & ? & ?); auto. *)
+(*     simpl in H0. *)
+(*     inv H0. *)
+(* Qed. *)
+
+Lemma subG_typ_es: forall G1 G2 es Ts,
+    subseteq G1 G2 -> typ_es G1 es Ts -> typ_es G2 es Ts.
+Proof.
+  induction es; destruct Ts; auto; intros.
+  autorewrite with typ_es in *.
+  destruct H0.
+  split; auto.
+  eapply subG_type; eauto.
+Qed.
+
+Lemma subG_typ_rhs: forall G1 G2 r T0,
+    subseteq G1 G2 -> typ_rhs G1 r T0 -> typ_rhs G2 r T0.
+Proof.
+  intros.
+  inv H0.
+  - econstructor.
+    eapply subG_type; eauto.
+  - econstructor; eauto.
+    eapply subG_typ_es; eauto.
+  - econstructor.
+    eapply lookup_weaken; eauto.
+Qed.
+
+Lemma subG_stmt_wt: forall G1 G2 st,
+    subseteq G1 G2 -> stmt_well_typed G1 st -> stmt_well_typed G2 st.
+Proof.
+  intros.
+  induction H0; eauto;
+    try (now econstructor; eauto).
+  - econstructor.
+    + eapply lookup_weaken; eauto.
+    + eapply subG_typ_rhs; eauto.
+  - econstructor; eauto.
+    eapply subG_type; eauto.
+  - econstructor; eauto.
+    eapply subG_type; eauto.
+  - econstructor.
+    + eapply subG_type; eauto.
+    + eapply lookup_weaken; eauto.
+Qed.
+
+Lemma subG_task_wt : forall Γ1 Γ2 t,
+    Γ1 ⊆ Γ2 -> task_well_typed  Γ1 t -> task_well_typed  Γ2 t.
+Proof.
+  intros.
+  destruct t.
+  - destruct t.
+    constructor.
+    inv H0.
+    eapply subG_stmt_wt; eauto.
+  - constructor.
+Qed.
+
+Lemma subG_queue_wt : forall Γ1 Γ2 q,
+    Γ1 ⊆ Γ2 -> queue_well_typed  Γ1 q -> queue_well_typed  Γ2 q.
+Proof.
+  intros*.
+  eapply subG_task_wt; eauto.
+Qed.
+
+Lemma fresh_extend_wt: forall Γ σ f,
+    config_well_typed Γ σ ->
+    fresh f σ ->
+    forall T_,
+      config_well_typed (<[f:=T_]> Γ) σ.
+Proof.
+  intros.
+  intros i ob LUi.
+  remember (id_of f) as fi.
+  is_eq i fi; subst.
+  - pose proof id_of_well_typed _ _ _ LUi as FUT.
+    inv FUT.
+    pose proof H0 _ _ _ LUi.
+    pose proof id_of_consistent _ _ _ _ LUi as <- .
+    contradiction.
+  - epose proof H i ob LUi.
+    destruct ob.
+    + enough (diff : f <> f0).
+      {
+        destruct v.
+        - inv H1.
+          econstructor; auto.
+          + setoid_rewrite lookup_insert_ne; eauto.
+          + inv H6; constructor.
+        - inv H1.
+          econstructor.
+          setoid_rewrite lookup_insert_ne; eauto.
+      }
+      intro.
+      replace i with (id_of (name_of i)) in *
+          by apply id_of_name_of.
+      pose proof id_of_consistent _ _ _ _ LUi.
+      subst.
+      contradiction.
+    + admit.
+    (* adding a future to the context does not impact typing of an object *)
+    + admit.
+      (* for invocations it is less obvious *)
+Admitted.
+
+Lemma bind_wt: forall m Ts T CL vs f tsk,
+    match_method m Ts T CL ->
+    bind m vs f CL = tsk ->
+    forall Γ,
+      Γ !! f = Some (ctxv_fut T) ->
+      typ_es Γ (map e_t vs) Ts ->
+      task_well_typed Γ tsk.
+Proof.
+Admitted.
+
+Lemma insert_lookup_ne_extend: forall Γ i j T_ l,
+    i <> j ->
+    extend_G (<[j:=T_]> Γ) l !! i = extend_G Γ l !! i.
+Proof.
+  induction l; intros; simpl.
+  - now apply lookup_insert_ne.
+  - unfold add_G; destruct a; simpl.
+    is_eq i x.
+    + now setoid_rewrite lookup_insert.
+    + setoid_rewrite lookup_insert_ne; eauto.
+Qed.
+
+Definition CL_well_typed: G -> CL -> Prop := fun _ _ => True. (*TODO: implement*)
+
+Lemma CL_wt_fields_fresh: forall Γ C,
+    CL_well_typed Γ C ->
+    Forall (λ '(_, x), x ∉ dom Γ) (get_fields C).
+Admitted.
+(* arguably too strong, we only really need them to agree *)
+(* replace subG_extend with a weaker version *)
+
+Lemma CL_wt_add_f: forall Γ C (f:f) T,
+    CL_well_typed Γ C ->
+    CL_well_typed (<[f:=T]> Γ) C.
+Admitted.
+
+Lemma Forall_typ_F_extension: forall Γ Fs Cl,
+    Forall (typ_F Γ) Fs ->
+    Forall (CL_well_typed Γ) Cs ->
+    In Cl Cs ->
+    Forall (typ_F (extend_G Γ (get_fields Cl))) Fs.
+Admitted.
+
+Theorem type_preservation : forall (Γ: G),
+    Forall (typ_F Γ) Fs ->
+    Forall (CL_well_typed Γ) Cs ->
+    forall σ σ',
+      config_well_typed Γ σ ->
+      stmt_step Cs Fs id_of σ σ' ->
+      exists Γ', Γ ⊆ Γ' /\ config_well_typed Γ' σ'.
+Proof.
+  intros Γ TYP_Fs TYP_Cs σ σ' WT STEP.
+  inv STEP.
+  - exists Γ; split; auto.
+    intros*.
+    lookup_cases H1 i i0.
+    + specialize (WT _ _ H0).
+      unfold_typing.
+      destruct p.
+      econstructor; eauto.
+      now apply q_wt_remove.
+    + eapply WT;eauto.
+
+  - destruct H0 as [sf ?].
+    pose proof WT as Conf_wt.
+    specialize (WT _ _ H1).
+    unfold_typing.
+    epose proof type_preservation _ _ _ _ _ _ _ _ _ H4 H0
+      as (?Γ & ?SUB & ? & ?TYP_E).
+    (* are tasks actually well-typed under this extension? *)
+    eexists.
+    split; eauto.
+    intros*.
+    lookup_cases H3 i i0.
+    + econstructor; eauto.
+      econstructor; eauto.
+    + eapply Conf_wt; eauto.
+
+  - destruct H0 as [sf ?].
+    pose proof WT as Conf_wt.
+    specialize (WT _ _ H1).
+    unfold_typing.
+    epose proof type_preservation _ _ _ _ _ _ _ _ _ H4 H0
+      as (?Γ & ?SUB & ? & ?TYP_E).
+    exists Γ0.
+    split.
+    + eapply extend_subG_2; eauto.
+      apply CL_wt_fields_fresh.
+      eapply Forall_forall; eauto.
+      eapply get_class_decl_some; eauto.
+    + intros*.
+      lookup_cases H3 o i.
+      * assert (extend_G Γ (get_fields Cl) ⊆ extend_G Γ0 (get_fields Cl)). {
+          eapply extend_subG.
+          eapply extend_subG_2; eauto.
+          apply CL_wt_fields_fresh.
+          eapply Forall_forall; eauto.
+          eapply get_class_decl_some; eauto.
+        }
+        econstructor; eauto.
+        -- eapply subG_queue_wt; eauto.
+        -- constructor.
+            eapply subG_stmt_wt; eauto.
+        -- admit. (* here we are lost without consistency of a *)
+      * admit. (* we need cn_well_typed closed under extensions *)
+
+  (* the trivial cases (ifs, skips, loops) are very similar*)
+  (* TODO: automate *)
+  - pose proof WT as Conf_wt.
+    specialize (WT _ _ H0).
+    unfold_typing.
+    exists Γ; split; auto.
+    intros*.
+    lookup_cases H1 o i.
+    + repeat (econstructor; eauto).
+    + eapply Conf_wt; eauto.
+
+  - pose proof WT as Conf_wt.
+    specialize (WT _ _ H0).
+    unfold_typing.
+    exists Γ; split; auto.
+    intros*.
+    lookup_cases H1 o i.
+    + repeat (econstructor; eauto).
+    + eapply Conf_wt; eauto.
+
+  - pose proof WT as Conf_wt.
+    specialize (WT _ _ H).
+    unfold_typing.
+    exists Γ; split; auto.
+    intros*.
+    lookup_cases H0 o i.
+    + repeat (econstructor; eauto).
+    + eapply Conf_wt; eauto.
+
+  - pose proof WT as Conf_wt.
+    specialize (WT _ _ H).
+    unfold_typing.
+    exists Γ; split; auto.
+    intros*.
+    lookup_cases H0 o i.
+    + repeat (econstructor; eauto).
+    + eapply Conf_wt; eauto.
+
+  - pose proof WT as Conf_wt.
+    specialize (WT _ _ H).
+    unfold_typing.
+    exists Γ; split; auto.
+    intros*.
+    lookup_cases H0 o i.
+    + repeat (econstructor; eauto).
+    + eapply Conf_wt; eauto.
+
+  - pose proof WT as Conf_wt.
+    specialize (WT _ _ H2).
+    unfold_typing.
+    pose proof H16 as Method_wt.
+    inv H16.
+    destruct method.
+    autorewrite with get_type get_params in *.
+    epose proof type_preservation_eval_list _ _ _ _ _ _ _ H13 H1 as TYP_ARGS.
+    exists (<[f:=ctxv_fut T_5]> Γ).
+    split.
+    + apply subG_add; auto.
+      apply not_elem_of_dom.
+      eapply fresh_config_wt; eauto.
+    + intros*.
+      lookup_cases H4 oi i0.
+      * econstructor; eauto.
+        -- eapply subG_queue_wt; last apply H10.
+            eapply extend_subG.
+            apply subG_add; auto.
+            apply not_elem_of_dom_1.
+            eapply fresh_config_wt; eauto.
+        -- constructor.
+            econstructor.
+            ++ econstructor; eauto.
+              ** rewrite insert_lookup_ne_extend; eauto.
+              ** econstructor.
+                  eapply lookup_weaken with (<[f:=ctxv_fut T_5]> Γ).
+                  --- now setoid_rewrite lookup_insert.
+                  --- apply subG_extend.
+                      apply CL_wt_fields_fresh.
+                      apply CL_wt_add_f.
+                      eapply Forall_forall; eauto.
+                      eapply get_class_decl_some; eauto.
+            ++ eapply subG_stmt_wt; last apply H9.
+              eapply extend_subG.
+              apply subG_add; auto.
+              apply not_elem_of_dom_1.
+              eapply fresh_config_wt; eauto.
+        -- admit. (* should follow from freshness *)
+
+      * lookup_cases H4 i i0.
+        -- econstructor; eauto.
+            ++ apply lookup_insert.
+            ++ eapply typ_term_list_invariant; eauto.
+        -- set (fi:=id_of f).
+            is_eq fi i0; subst fi.
+            ++ setoid_rewrite lookup_insert in H4.
+              inv H4.
+              econstructor.
+              apply lookup_insert.
+            ++ setoid_rewrite lookup_insert_ne in H4; auto.
+              eapply fresh_extend_wt; eauto.
+
+  - pose proof WT _ _ H0 as fut_well_typed.
+    pose proof WT _ _ H1 as ob_well_typed.
+    exists Γ; split; auto.
+    intros*.
+    unfold_typing.
+    lookup_cases H3 o i.
+    + econstructor; eauto.
+      econstructor.
+    + lookup_cases H3 fi i.
+      * econstructor; eauto.
+        epose proof type_preservation_eval _ _ _ _ _ _ _ H5 H.
+        enough (T0 = T) by (subst; inv H3; constructor).
+        (* now we have a problem since the local state is not required to be consistent *)
+        (* pose proof (H15 _ _ H5) as (?t & ? & ?); simp. *)
+        (* inv H1; inv H9. *)
+        admit.
+      * eapply WT; eauto.
+
+  - pose proof WT _ _ H as fut_well_typed.
+    pose proof WT _ _ H0 as ob_well_typed.
+    exists Γ; split; auto.
+    intros*.
+    unfold_typing.
+    lookup_cases H1 o i.
+    + repeat (econstructor; eauto).
+      enough (T1 = T) by (subst; eapply typ_term_invariant; eauto).
+      eapply lookup_weaken with (m2:=extend_G Γ (get_fields Cl)) in H5.
+      now simp.
+      apply subG_extend.
+      apply CL_wt_fields_fresh.
+      eapply Forall_forall; eauto.
+      eapply get_class_decl_some; eauto.
+    + eapply WT; eauto.
+
+  - pose proof WT _ _ H as ob_well_typed.
+    pose proof WT _ _ H0 as inv_well_typed.
+    exists Γ; split; auto.
+    intros*.
+    unfold_typing.
+    + lookup_cases H2 oi i0.
+      * repeat (econstructor; eauto).
+        apply q_wt_add; auto.
+        replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
+        eapply bind_wt; eauto.
+        -- apply lookup_weaken with Γ; auto.
+            apply subG_extend.
+            apply CL_wt_fields_fresh.
+            eapply Forall_forall; eauto.
+            eapply get_class_decl_some; eauto.
+        -- eapply subG_typ_es; last apply H10.
+            apply subG_extend.
+            apply CL_wt_fields_fresh.
+            eapply Forall_forall; eauto.
+            eapply get_class_decl_some; eauto.
+      * is_eq i i0.
+        -- exfalso.
+            setoid_rewrite (lookup_delete σ i) in H2.
+            inv H2.
+        -- setoid_rewrite lookup_delete_ne in H2; auto.
+            eapply WT; eauto.
+    + lookup_cases H2 oi i0.
+      * repeat (econstructor; eauto).
+        apply q_wt_add; auto.
+        replace CL with Cl in * by admit. (* by welformedness of class_of, probably *)
+        eapply bind_wt; eauto.
+        -- apply lookup_weaken with Γ; auto.
+            apply subG_extend.
+            apply CL_wt_fields_fresh.
+            eapply Forall_forall; eauto.
+            eapply get_class_decl_some; eauto.
+        -- eapply subG_typ_es; last apply H10.
+            apply subG_extend.
+            apply CL_wt_fields_fresh.
+            eapply Forall_forall; eauto.
+            eapply get_class_decl_some; eauto.
+
+      * is_eq i i0.
+        -- exfalso.
+            setoid_rewrite (lookup_delete σ i) in H2.
+            inv H2.
+        -- setoid_rewrite lookup_delete_ne in H2; auto.
+            eapply WT; eauto.
+
+            Unshelve.
+            all: try eauto.
+            all: try (now apply G_vdash_union).
+            all: apply Forall_typ_F_extension; auto;
+              eapply get_class_decl_some; eauto.
+Admitted.
+End Typing.
+(*TODO: labels + traces? *)


### PR DESCRIPTION
There are quite a few admits left. Many of them should be okay, but there are 3 I am not sure how to solve.

1. Well-typedness of tasks is not closed under extended typing contexts (see `subG_task_wt`). The trouble is that tasks carry local state which may contradict the extension. This becomes a problem because subject-reduction for the functional part gives us an extended context, so whenever we need to evaluate an expression it breaks typing for tasks.
In the ABS paper these local states are written as lists of typed variables "for convenience" which sidesteps the problem.
I am not sure how to solve this one, and it may require some changes to the typing relation.
2. As it stands, `fresh f config` and `Γ ⊢ config`  does *not* imply `f ∉ dom Γ` – essentially because `f ↦ T ⊢ ε`. Either well-typing or freshness needs to be stronger.
3. I am not quite sure how to handle class fields. In the typing rule for objects the context is extended with the fields, but doing so straightforwardly causes some problems with extensions. In particular, should we somehow make sure the field names are fresh w.r.t the context?