### PR TITLE
stop using coq-equality in Ott in favor of stdpp EqDecision

### DIFF
--- a/src/abs.ott
+++ b/src/abs.ott
@@ -3,56 +3,43 @@ embed
 From Equations Require Import Equations.
 From stdpp Require Import prelude strings gmap gmultiset countable.
 
-#[export] Hint Resolve bool_dec : ott_coq_equality.
-#[export] Hint Resolve Ascii.ascii_dec : ott_coq_equality.
-#[export] Hint Resolve BinPos.Pos.eq_dec : ott_coq_equality.
-
 (** * ABS Definitions *)
 }}
 indexvar i, j, n ::=
       {{ lex numeral }}
       {{ coq nat }}
-      {{ coq-equality }}
       {{ com index variables (subscripts) }}
 metavar fc ::=
       {{ lex Alphanum }}
       {{ coq string }}
-      {{ coq-equality }}
       {{ com function name }}
 metavar x, y ::=
       {{ lex alphanum }}
       {{ coq string }}
-      {{ coq-equality }}
       {{ com variable }}
 metavar fut ::=
   {{ lex numeral }}
   {{ com future type }}
-  {{ coq-equality }}
   {{ coq nat }}
 metavar f ::=
   {{ lex alphanum }}
   {{ com future name }}
-  {{ coq-equality }}
   {{ coq string }}
 metavar o ::=
   {{ lex alphanum }}
   {{ com object name }}
-  {{ coq-equality }}
   {{ coq string }}
 metavar m ::=
   {{ lex alphanum }}
   {{ com method name }}
-  {{ coq-equality }}
   {{ coq string }}
 metavar C ::=
   {{ lex alphanum }}
   {{ com class name }}
-  {{ coq-equality }}
   {{ coq string }}
 grammar
 z :: z_ ::=
   {{ com integer }}
-  {{ coq-equality }}
   {{ coq Z }}
 | z (+) z' :: M :: plus
   {{ coq (Z.add [[z]] [[z']]) }}
@@ -63,7 +50,6 @@ z :: z_ ::=
 
 b :: b_ ::=
   {{ com boolean }}
-  {{ coq-equality }}
   {{ coq bool }}
 | (!) b :: M :: not
   {{ coq (negb [[b]]) }}
@@ -206,7 +192,7 @@ embed
 
 Equations e_var_subst_one (e5:e) (x_ y_: x) : e := {
  e_var_subst_one (e_t t) _ _ := e_t t;
- e_var_subst_one (e_var x0) x_ y_ := if (eq_x x0 x_) then (e_var y_) else (e_var x0);
+ e_var_subst_one (e_var x0) x_ y_ := if decide (x0 = x_) then (e_var y_) else (e_var x0);
  e_var_subst_one (e_neg e0) _ _ := e_neg (e_var_subst_one e0 x_ y_);
  e_var_subst_one (e_not e0) _ _ := e_not (e_var_subst_one e0 x_ y_);
  e_var_subst_one (e_add e1 e2) _ _ := e_add (e_var_subst_one e1 x_ y_) (e_var_subst_one e2 x_ y_);

--- a/theories/abs_defs.v
+++ b/theories/abs_defs.v
@@ -9,60 +9,16 @@ Require Import Ott.ott_list_core.
 From Equations Require Import Equations.
 From stdpp Require Import prelude strings gmap gmultiset countable.
 
-#[export] Hint Resolve bool_dec : ott_coq_equality.
-#[export] Hint Resolve Ascii.ascii_dec : ott_coq_equality.
-#[export] Hint Resolve BinPos.Pos.eq_dec : ott_coq_equality.
-
 (** * ABS Definitions *)
 
 Definition i : Set := nat. (* index variables (subscripts) *)
-Lemma eq_i: forall (x y : i), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_i : ott_coq_equality.
 Definition fc : Set := string. (* function name *)
-Lemma eq_fc: forall (x y : fc), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_fc : ott_coq_equality.
 Definition x : Set := string. (* variable *)
-Lemma eq_x: forall (x' y : x), {x' = y} + {x' <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_x : ott_coq_equality.
 Definition fut : Set := nat. (* future type *)
-Lemma eq_fut: forall (x y : fut), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_fut : ott_coq_equality.
 Definition f : Set := string. (* future name *)
-Lemma eq_f: forall (x y : f), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_f : ott_coq_equality.
 Definition o : Set := string. (* object name *)
-Lemma eq_o: forall (x y : o), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_o : ott_coq_equality.
 Definition m : Set := string. (* method name *)
-Lemma eq_m: forall (x y : m), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_m : ott_coq_equality.
 Definition C : Set := string. (* class name *)
-Lemma eq_C: forall (x y : C), {x = y} + {x <> y}.
-Proof.
-  decide equality; auto with ott_coq_equality arith.
-Defined.
-#[export] Hint Resolve eq_C : ott_coq_equality.
 
 Definition z : Set := Z.
 
@@ -166,7 +122,7 @@ End e_rect.
 
 Equations e_var_subst_one (e5:e) (x_ y_: x) : e := {
  e_var_subst_one (e_t t) _ _ := e_t t;
- e_var_subst_one (e_var x0) x_ y_ := if (eq_x x0 x_) then (e_var y_) else (e_var x0);
+ e_var_subst_one (e_var x0) x_ y_ := if decide (x0 = x_) then (e_var y_) else (e_var x0);
  e_var_subst_one (e_neg e0) _ _ := e_neg (e_var_subst_one e0 x_ y_);
  e_var_subst_one (e_not e0) _ _ := e_not (e_var_subst_one e0 x_ y_);
  e_var_subst_one (e_add e1 e2) _ _ := e_add (e_var_subst_one e1 x_ y_) (e_var_subst_one e2 x_ y_);

--- a/theories/abs_functional_metatheory.v
+++ b/theories/abs_functional_metatheory.v
@@ -67,7 +67,7 @@ Proof.
 
     cbn.
     intros ?y ?T_ ?.
-    destruct (eq_x y y0); subst.
+    destruct (decide (y = y0)); subst.
   - exists t_.
     split; eauto with simpl_map.
     assert (T_ = get_type T_0).
@@ -190,7 +190,7 @@ Proof.
       now simpl.
     + destruct a.
       simpl.
-      destruct (eq_x (replace_var x5 sub_list) x); subst.
+      destruct (decide ((replace_var x5 sub_list) = x)); subst.
       * eapply H0; eauto.
         -- now left.
         -- apply IHsub_list; eauto.
@@ -285,14 +285,14 @@ Proof.
       inv H.
       apply lookup_insert_Some in H3.
       destruct H3 as [(?,?)|(?,?)]; subst.
-      + destruct (eq_x x5 x5); subst.
+      + destruct (decide (x5 = x5)); subst.
         * constructor.
           now simpl_map.
         * contradiction.
 
-      + destruct (eq_x x5 x0); subst.
+      + destruct (decide (x5 = x0)); subst.
         * contradiction.
-        * destruct (eq_x x5 y0); subst.
+        * destruct (decide (x5 = y0)); subst.
           -- simp fresh_vars_e in H0.
              exfalso.
              apply H0.

--- a/theories/abs_util.v
+++ b/theories/abs_util.v
@@ -45,7 +45,7 @@ Proof.
 Qed.
 
 Definition replace_var (x0:x) (sub:list(x*x)) :=
- fold_right (fun '(x_, y_) x0 => if (eq_x x0 x_) then y_ else x0) x0 sub.
+ fold_right (fun '(x_, y_) x0 => if decide (x0 = x_) then y_ else x0) x0 sub.
 
 Lemma subst_var: forall x0 sub,
   e_var_subst (e_var x0) sub = e_var (replace_var x0 sub).
@@ -55,7 +55,7 @@ Proof.
   - destruct a; simpl.
     rewrite IHsub.
     simp e_var_subst_one.
-    destruct (eq_x (replace_var x0 sub)); subst; eauto.
+    case_decide; subst; eauto.
 Qed.
 
 Lemma e_list_subst_map: forall x0 y0 e_list,
@@ -256,12 +256,12 @@ Proof.
     destruct a as (?x_, ?y); simpl.
     rewrite subst_var.
     simp e_var_subst_one.
-    destruct (eq_x (replace_var x5 sub) x_).
+    case_decide.
     + simp fresh_vars_e.
       intro.
       apply H1.
       left.
-      now inv H2.
+      now inv H3.
     + rewrite <- subst_var.
       apply Decidable.not_or in H1.
       destruct H1.


### PR DESCRIPTION
As shown here, adopting `EqDecision` makes other forms of decidable equality management obsolete. Will merge when CI passes.